### PR TITLE
User Credentials api

### DIFF
--- a/credentials/apps/api/accreditors.py
+++ b/credentials/apps/api/accreditors.py
@@ -1,0 +1,57 @@
+# pylint:  disable=missing-docstring
+from __future__ import unicode_literals
+import logging
+
+from credentials.apps.api import exceptions
+from credentials.apps.credentials.issuers import ProgramCertificateIssuer
+
+
+logger = logging.getLogger(__name__)
+
+
+class Accreditor(object):
+    """ Accreditor class identifies credential type and calls corresponding issuer
+    class for generating credential.
+    """
+    def __init__(self, issuers=None):
+        self.issuers = issuers or [ProgramCertificateIssuer()]
+        self._create_credential_type_issuer_map()
+
+    def _create_credential_type_issuer_map(self):
+        """Creates a map from credential type to a list of credential issuers."""
+        self.credential_type_issuer_map = {}
+        for issuer in self.issuers:
+            credential_type = issuer.issued_credential_type
+            registered_issuer = self.credential_type_issuer_map.get(credential_type)
+
+            if not registered_issuer:
+                self.credential_type_issuer_map[credential_type] = issuer
+            else:
+                logger.warning(
+                    "The issuer [%s] is already registered to issue credentials of type [%s]. [%s] will NOT be used.",
+                    registered_issuer.__class__, credential_type, issuer.__class__)
+
+    def issue_credential(self, credential, username, attributes=None):
+        """Issues a credential.
+
+        Arguments:
+            credential (AbstractCredential): Type of credential to issue.
+            username (string): Username of the recipient.
+            attributes (List[dict]): attributes list containing dictionaries of attributes
+
+        Returns:
+            UserCredential
+
+        Raises:
+            UnsupportedCredentialTypeError: If the specified credential type is not supported (cannot be issued).
+        """
+        try:
+            credential_issuer = self.credential_type_issuer_map[credential.__class__]
+        except KeyError:
+            raise exceptions.UnsupportedCredentialTypeError(
+                "Unable to issue credential. No issuer is registered for credential type [{}]".format(
+                    credential
+                )
+            )
+
+        return credential_issuer.issue_credential(credential, username, attributes)

--- a/credentials/apps/api/exceptions.py
+++ b/credentials/apps/api/exceptions.py
@@ -1,0 +1,15 @@
+"""Exceptions and error messages used by the credentials API."""
+from __future__ import unicode_literals
+
+
+class UnsupportedCredentialTypeError(Exception):
+    """ Raised when the Accreditor is asked to issue a type of credential
+    for which there is no registered issuer. """
+    pass
+
+
+class DuplicateAttributeError(Exception):
+    """ Raised when the Accreditor is asked to issue credential with duplicate
+    attributes.
+    """
+    pass

--- a/credentials/apps/api/models.py
+++ b/credentials/apps/api/models.py
@@ -1,4 +1,0 @@
-# Models that can be shared across multiple versions of the API
-# should be created here. As the API evolves, models may become more
-# specific to a particular version of the API. In this case, the models
-# in question should be moved to versioned sub-package.

--- a/credentials/apps/api/tests/factories.py
+++ b/credentials/apps/api/tests/factories.py
@@ -1,0 +1,84 @@
+"""
+Factories for credential models.
+"""
+# pylint: disable=missing-docstring
+
+import uuid  # pylint: disable=unused-import
+
+import factory
+from django.conf import settings
+from django.contrib.sites.models import Site
+
+from credentials.apps.credentials import constants, models
+
+
+PASSWORD = 'dummy-password'
+
+
+class SiteFactory(factory.django.DjangoModelFactory):
+    class Meta(object):
+        model = Site
+
+
+class CertificateTemplateFactory(factory.django.DjangoModelFactory):
+    class Meta(object):
+        model = models.CertificateTemplate
+
+    name = factory.Sequence(lambda n: 'template%d' % n)
+    content = '<html></html>'
+
+
+class SiteCertificateTemplateBaseFactory(factory.django.DjangoModelFactory):
+    site = factory.SubFactory(SiteFactory)
+    template = factory.SubFactory(CertificateTemplateFactory)
+    title = 'dummy title'
+
+
+class ProgramCertificateFactory(SiteCertificateTemplateBaseFactory):
+    class Meta(object):
+        model = models.ProgramCertificate
+
+    program_id = factory.Sequence(int)
+
+
+class CourseCertificateFactory(SiteCertificateTemplateBaseFactory):
+    class Meta(object):
+        model = models.CourseCertificate
+
+    course_id = factory.Sequence(lambda o: 'course-%d' % o)
+    certificate_type = constants.CertificateType.HONOR
+
+
+class UserCredentialFactory(factory.django.DjangoModelFactory):
+    class Meta(object):
+        model = models.UserCredential
+
+    credential = factory.SubFactory(ProgramCertificateFactory)
+    username = factory.Sequence(lambda o: 'robot%d' % o)
+    status = models.UserCredential.AWARDED
+    download_url = 'http://www.google.com'
+    uuid = factory.LazyAttribute(lambda o: uuid.uuid4())  # pylint: disable=undefined-variable
+
+
+class UserCredentialAttributeFactory(factory.django.DjangoModelFactory):
+    class Meta(object):
+        model = models.UserCredentialAttribute
+
+    user_credential = factory.SubFactory(UserCredentialFactory)
+    namespace = factory.Sequence(lambda o: u'namespace-%d' % o)
+    name = factory.Sequence(lambda o: u'name-%d' % o)
+    value = factory.Sequence(lambda o: u'value-%d' % o)
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    username = factory.Sequence(lambda o: 'robot%d' % o)
+    email = factory.LazyAttribute(lambda obj: '%s@edx.org' % obj.username)
+    first_name = 'robot'
+    last_name = 'user'
+    password = factory.PostGenerationMethodCall('set_password', PASSWORD)
+    is_active = True
+    is_superuser = False
+    is_staff = False
+
+    class Meta(object):
+        model = settings.AUTH_USER_MODEL

--- a/credentials/apps/api/tests/test_accreditors.py
+++ b/credentials/apps/api/tests/test_accreditors.py
@@ -1,0 +1,67 @@
+"""
+Tests for the accreditor module.
+"""
+from __future__ import unicode_literals
+
+from django.test import TestCase
+from mock import patch
+from testfixtures import LogCapture
+
+from credentials.apps.api.accreditors import Accreditor
+from credentials.apps.api.exceptions import UnsupportedCredentialTypeError
+from credentials.apps.api.tests.factories import CourseCertificateFactory, ProgramCertificateFactory
+from credentials.apps.credentials.issuers import ProgramCertificateIssuer
+from credentials.apps.credentials.models import ProgramCertificate
+
+
+LOGGER_NAME = 'credentials.apps.api.accreditors'
+
+
+class AccreditorTests(TestCase):
+    """ Tests for Accreditor class. This class is responsible to call the right
+    credential issuer class to generate the credential.
+    """
+
+    def setUp(self):
+        super(AccreditorTests, self).setUp()
+        self.accreditor = Accreditor()
+        self.program_cert = ProgramCertificateFactory()
+        self.program_credential = ProgramCertificate
+        self.attributes = [{"namespace": "whitelist", "name": "whitelist", "value": "some reason"}]
+
+    def test_create_credential_type_issuer_map(self):
+        """ Verify the Accreditor supports only one issuer per credential type. """
+        accreditor = Accreditor(issuers=[ProgramCertificateIssuer(), ProgramCertificateIssuer()])
+
+        expected = {
+            self.program_credential: accreditor.issuers[0]
+        }
+        self.assertEqual(accreditor.credential_type_issuer_map, expected)
+
+    def test_issue_credential_with_invalid_type(self):
+        """ Verify the method raises an error for attempts to issue an unsupported credential type. """
+        course_cert = CourseCertificateFactory()
+        with self.assertRaises(UnsupportedCredentialTypeError):
+            self.accreditor.issue_credential(course_cert, 'tester', self.attributes)
+
+    def test_issue_credential(self):
+        """ Verify the method calls the Issuer's issue_credential method. """
+        with patch.object(ProgramCertificateIssuer, 'issue_credential') as mock_method:
+            self.accreditor.issue_credential(self.program_cert, 'tester', self.attributes)
+            mock_method.assert_called_with(self.program_cert, 'tester', self.attributes)
+
+    def test_constructor_with_multiple_issuers_for_same_credential_type(self):
+        """ Verify the Accreditor supports a single Issuer per credential type.
+        Attempts to register additional issuers for a credential type should
+        result in a warning being logged.
+        """
+        # pylint: disable=no-member
+        msg = "The issuer [{}] is already registered to issue credentials of type [{}]. [{}] will NOT be used.".format(
+            ProgramCertificateIssuer, self.program_credential, ProgramCertificateIssuer
+        )
+
+        with LogCapture(LOGGER_NAME) as l:
+            accreditor = Accreditor(issuers=[ProgramCertificateIssuer(), ProgramCertificateIssuer()])
+            l.check((LOGGER_NAME, 'WARNING', msg))
+        expected = {self.program_credential: accreditor.issuers[0]}
+        self.assertEqual(accreditor.credential_type_issuer_map, expected)

--- a/credentials/apps/api/tests/test_serializers.py
+++ b/credentials/apps/api/tests/test_serializers.py
@@ -1,0 +1,180 @@
+""" Tests for Credit API serializers. """
+# pylint: disable=no-member
+from __future__ import unicode_literals
+import ddt
+
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+from rest_framework.settings import api_settings
+
+from credentials.apps.api import serializers
+from credentials.apps.api.tests.factories import (
+    CourseCertificateFactory, ProgramCertificateFactory,
+    UserCredentialFactory, UserCredentialAttributeFactory
+)
+
+
+class UserCredentialSerializerTests(TestCase):
+    """ UserCredentialSerializer tests. """
+
+    def setUp(self):
+        super(UserCredentialSerializerTests, self).setUp()
+
+        self.program_cert = ProgramCertificateFactory()
+        self.program_credential = UserCredentialFactory(credential=self.program_cert)
+        self.program_cert_attr = UserCredentialAttributeFactory(user_credential=self.program_credential)
+
+        self.course_cert = CourseCertificateFactory.create()
+        self.course_credential = UserCredentialFactory.create(credential=self.course_cert)
+        self.course_cert_attr = UserCredentialAttributeFactory(user_credential=self.course_credential)
+
+    def test_serialization_with_program_credential(self):
+        """ Verify the serializer correctly serializes program credentials."""
+        actual = serializers.UserCredentialSerializer(self.program_credential).data
+        expected = {
+            "username": self.program_credential.username,
+            "uuid": str(self.program_credential.uuid),
+            "credential": {
+                "program_id": self.program_cert.program_id,
+                "credential_id": self.program_cert.id,
+            },
+            "download_url": self.program_credential.download_url,
+            "status": self.program_credential.status,
+            "attributes": [
+                {
+                    "namespace": self.program_cert_attr.namespace,
+                    "name": self.program_cert_attr.name,
+                    "value": self.program_cert_attr.value
+                }
+            ],
+            "id": self.program_credential.id,
+            "created": self.program_credential.created.strftime(api_settings.DATETIME_FORMAT),
+            "modified": self.program_credential.modified.strftime(api_settings.DATETIME_FORMAT)
+        }
+        self.assertEqual(actual, expected)
+
+    def test_serialization_with_course_credential(self):
+        """ Verify the serializer correctly serializes course credentials."""
+
+        actual = serializers.UserCredentialSerializer(self.course_credential).data
+        expected = {
+            "username": self.course_credential.username,
+            "uuid": str(self.course_credential.uuid),
+            "credential": {
+                "course_id": self.course_cert.course_id,
+                "certificate_type": self.course_cert.certificate_type,
+                "credential_id": self.course_cert.id
+            },
+            "download_url": self.course_credential.download_url,
+            "status": self.course_credential.status,
+            "attributes": [
+                {
+                    "namespace": self.course_cert_attr.namespace,
+                    "name": self.course_cert_attr.name,
+                    "value": self.course_cert_attr.value
+                }
+            ],
+            "id": self.course_credential.id,
+            "created": self.course_credential.created.strftime(api_settings.DATETIME_FORMAT),
+            "modified": self.course_credential.modified.strftime(api_settings.DATETIME_FORMAT)
+        }
+        self.assertEqual(actual, expected)
+
+
+class UserCredentialAttributeSerializerTests(TestCase):
+    """ CredentialAttributeSerializer tests. """
+
+    def setUp(self):
+        super(UserCredentialAttributeSerializerTests, self).setUp()
+        self.program_cert = ProgramCertificateFactory()
+        self.program_credential = UserCredentialFactory(credential=self.program_cert)
+        self.program_cert_attr = UserCredentialAttributeFactory(user_credential=self.program_credential)
+
+    def test_data(self):
+        """ Verify that user CredentialAttributeSerializer serialize data correctly."""
+        serialize_data = serializers.UserCredentialAttributeSerializer(self.program_cert_attr)
+        expected = {
+            "namespace": self.program_cert_attr.namespace,
+            "name": self.program_cert_attr.name,
+            "value": self.program_cert_attr.value
+        }
+
+        self.assertEqual(serialize_data.data, expected)
+
+
+@ddt.ddt
+class CredentialFieldTests(TestCase):
+    """ CredentialField tests. """
+
+    def setUp(self):
+        super(CredentialFieldTests, self).setUp()
+        self.program_cert = ProgramCertificateFactory()
+        self.field_instance = serializers.CredentialField()
+
+    @ddt.data(
+        {"program_id": ""},
+        {"course_id": ""},
+        {"course_id": 404, 'certificate_type': ''},
+    )
+    def test_to_internal_value_with_empty_credential(self, credential_data):
+        """Verify that it will return error message if credential-id attributes are empty."""
+
+        with self.assertRaisesRegexp(ValidationError, "Credential ID is missing"):
+            self.field_instance.to_internal_value(credential_data)
+
+    def test_to_internal_value_with_invalid_program_credential(self,):
+        """Verify that it will return error message if program-id does not exist in db."""
+
+        with self.assertRaisesRegexp(ValidationError, "ProgramCertificate matching query does not exist."):
+            self.field_instance.to_internal_value({"program_id": 404})
+
+    def test_to_internal_value_with_invalid_course_credential(self):
+        """Verify that it will return error message if course-id does not exist in db."""
+
+        with self.assertRaisesRegexp(ValidationError, "CourseCertificate matching query does not exist."):
+            self.field_instance.to_internal_value({"course_id": 404, 'certificate_type': "honor"})
+
+    def test_to_internal_value_with_valid_program_credential(self):
+        """Verify that it will return credential object if program-id found in db."""
+
+        self.assertEqual(
+            self.program_cert,
+            self.field_instance.to_internal_value({"program_id": self.program_cert.program_id})
+        )
+
+    def test_to_internal_value_with_valid_course_credential(self):
+        """Verify that it will return credential object if course-id and certificate type
+        found in db."""
+
+        course_cert = CourseCertificateFactory()
+        self.assertEqual(
+            course_cert,
+            self.field_instance.to_internal_value({"course_id": course_cert.course_id, "certificate_type": "honor"})
+        )
+
+    def test_to_representation_data_with_program(self):
+        """Verify that it will return program certificate credential object in dict format."""
+
+        expected_data = {"program_id": self.program_cert.program_id, "credential_id": self.program_cert.id}
+        self.assertEqual(
+            expected_data,
+            self.field_instance.to_representation(
+                self.program_cert
+            )
+        )
+
+    def test_to_representation_with_course(self):
+        """Verify that it will return course certificate credential object in dict format."""
+
+        course_cert = CourseCertificateFactory()
+        expected_data = {
+            "course_id": course_cert.course_id,
+            "credential_id": course_cert.id,
+            "certificate_type": course_cert.certificate_type
+        }
+        self.assertEqual(
+            expected_data,
+            self.field_instance.to_representation(
+                course_cert
+            )
+        )

--- a/credentials/apps/api/tests/test_views.py
+++ b/credentials/apps/api/tests/test_views.py
@@ -1,0 +1,371 @@
+"""
+Tests for credentials service views.
+"""
+from __future__ import unicode_literals
+import json
+
+import ddt
+from django.contrib.auth.models import Permission
+from django.core.urlresolvers import reverse
+from rest_framework.test import APITestCase
+from testfixtures import LogCapture
+
+from credentials.apps.api.serializers import UserCredentialSerializer
+from credentials.apps.api.tests import factories
+from credentials.apps.credentials.models import UserCredential
+
+
+JSON_CONTENT_TYPE = 'application/json'
+LOGGER_NAME = 'credentials.apps.credentials.issuers'
+LOGGER_NAME_SERIALIZER = 'credentials.apps.api.serializers'
+
+
+@ddt.ddt
+class UserCredentialViewSetTests(APITestCase):
+    """ Tests for GenerateCredentialView. """
+
+    list_path = reverse("api:v1:usercredential-list")
+
+    def setUp(self):
+        super(UserCredentialViewSetTests, self).setUp()
+
+        self.user = factories.UserFactory()
+        self.client.force_authenticate(self.user)  # pylint: disable=no-member
+
+        self.program_cert = factories.ProgramCertificateFactory()
+        self.program_id = self.program_cert.program_id
+        self.user_credential = factories.UserCredentialFactory.create(credential=self.program_cert)
+        self.user_credential_attribute = factories.UserCredentialAttributeFactory.create(
+            user_credential=self.user_credential)
+
+    def _attempt_update_user_credential(self, data):
+        """ Helper method that attempts to patch an existing credential object.
+
+        Arguments:
+          data (dict): Data to be converted to JSON and sent to the API.
+
+        Returns:
+          Response: HTTP response from the API.
+        """
+        # pylint: disable=no-member
+        self.user.user_permissions.add(Permission.objects.get(codename="change_usercredential"))
+        path = reverse("api:v1:usercredential-detail", args=[self.user_credential.id])
+        return self.client.patch(path=path, data=json.dumps(data), content_type=JSON_CONTENT_TYPE)
+
+    def test_get(self):
+        """ Verify a single user credential is returned. """
+
+        path = reverse("api:v1:usercredential-detail", args=[self.user_credential.id])
+        response = self.client.get(path)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, UserCredentialSerializer(self.user_credential).data)
+
+    def test_list_without_username(self):
+        """ Verify a list end point of user credentials will work only with
+        username filter. Otherwise it will return 400.
+        """
+        response = self.client.get(self.list_path)
+        self.assertEqual(response.status_code, 400)
+
+    def test_partial_update(self):
+        """ Verify the only status field can be updated. """
+        data = {
+            'id': self.user_credential.id,
+            'status': UserCredential.REVOKED,
+            'download_url': self.user_credential.download_url + 'test'
+        }
+
+        response = self._attempt_update_user_credential(data)
+        self.assertEqual(response.status_code, 200)
+
+        user_credential = UserCredential.objects.get(id=self.user_credential.id)
+        self.assertEqual(user_credential.status, data["status"])
+        self.assertEqual(user_credential.download_url, self.user_credential.download_url)
+
+    def test_partial_update_authentication(self):
+        """ Verify that patch endpoint allows only authorized users to update
+        user credential.
+        """
+        self.client.logout()
+        data = {
+            "id": self.user_credential.id,
+            "download_url": "dummy-url",
+        }
+
+        path = reverse("api:v1:usercredential-detail", args=[self.user_credential.id])
+        response = self.client.patch(path=path, data=json.dumps(data), content_type=JSON_CONTENT_TYPE)
+        self.assertEqual(response.status_code, 403)
+
+    def _attempt_create_user_credentials(self, data):
+        """ Helper method that attempts to create user credentials.
+
+        Arguments:
+          data (dict): Data to be converted to JSON and sent to the API.
+
+        Returns:
+          Response: HTTP response from the API.
+        """
+        # pylint: disable=no-member
+        self.user.user_permissions.add(Permission.objects.get(codename="add_usercredential"))
+        path = self.list_path
+        return self.client.post(path=path, data=json.dumps(data), content_type=JSON_CONTENT_TYPE)
+
+    @ddt.data(
+        ("username", "", "This field may not be blank."),
+        ("credential", "", "Credential ID is missing."),
+        ("credential", {"program_id": ""}, "Credential ID is missing."),
+        ("credential", {"course_id": ""}, "Credential ID is missing."),
+    )
+    @ddt.unpack
+    def test_create_with_empty_fields(self, field_name, value, err_msg):
+        """ Verify no UserCredential is created, and HTTP 400 is returned, if
+        required fields are missing.
+        """
+        data = {
+            "username": "test_user",
+            "credential": {"program_id": self.program_id},
+            "attributes": [
+                {
+                    "namespace": "testing",
+                    "name": "grade",
+                    "value": "0.8"
+                }
+            ]
+        }
+        data.update({field_name: value})
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data.get(field_name),
+            [err_msg]
+        )
+
+    @ddt.data(
+        "username",
+        "credential",
+        "attributes",
+    )
+    def test_create_with_missing_fields(self, field_name):
+        """ Verify no UserCredential is created, and HTTP 400 is returned, if
+        required fields are missing.
+        """
+        username = "test_user"
+        data = {
+            "username": username,
+            "credential": {"program_id": self.program_id},
+            "attributes": [
+                {
+                    "namespace": "testing",
+                    "name": "grade",
+                    "value": "0.8"
+                }
+            ]
+        }
+        del data[field_name]
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data.get(field_name),
+            ['This field is required.']
+        )
+
+    def test_create_with_programcertificate(self):
+        """ Verify the endpoint supports issuing a new ProgramCertificate credential. """
+
+        program_certificate = factories.ProgramCertificateFactory()
+        username = 'user2'
+        data = {
+            "username": username,
+            "credential": {
+                "program_id": program_certificate.program_id
+            },
+            "attributes": [
+                {
+                    "namespace": self.user_credential_attribute.namespace,
+                    "name": self.user_credential_attribute.name,
+                    "value": self.user_credential_attribute.value
+                },
+                {
+                    "namespace": "testing",
+                    "name": "grade",
+                    "value": "0.8"
+                }
+            ]
+        }
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 201)
+        user_credential = UserCredential.objects.get(username=username)
+        self.assertEqual(json.loads(response.content), UserCredentialSerializer(user_credential).data)
+
+    def test_create_authentication(self):
+        """ Verify that the create endpoint of user credential does not allow
+        the unauthorized users to create a new user credential for the program.
+        """
+        self.client.logout()
+        path = self.list_path
+        response = self.client.post(path=path, data={}, content_type=JSON_CONTENT_TYPE)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_create_with_duplicate_attributes(self):
+        """ Verify no UserCredential is created, and HTTP 400 is returned, if
+        there are duplicated attributes.
+        """
+        username = 'test_user'
+        data = {
+            "username": username,
+            "credential": {"program_id": self.program_id},
+            "attributes": [
+                {
+                    "namespace": "white",
+                    "name": "grade",
+                    "value": "0.5"
+                },
+                {
+                    "namespace": "dummyspace",
+                    "name": "grade",
+                    "value": "0.6"
+                },
+                {
+                    "namespace": "white",
+                    "name": "grade",
+                    "value": "0.8"
+                },
+                {
+                    "namespace": "white",
+                    "name": "grade",
+                    "value": "0.8"
+                }
+            ]
+        }
+
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.data, {'attributes': ['Attributes cannot be duplicated.']})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(UserCredential.objects.filter(username=username).exists())
+
+    def test_create_with_empty_attributes(self):
+        """ Verify no UserCredential is created, and HTTP 400 is returned, if
+        there are some attributes are null.
+        """
+        username = 'test_user_duplicate_attr'
+        data = {
+            "username": username,
+            "credential": {"program_id": self.program_id},
+            "attributes": [
+                {
+                    "namespace": "white",
+                    "name": "grade",
+                    "value": "0.5"
+                },
+                {
+                    "namespace": "",
+                    "name": "grade",
+                    "value": "0.8"
+                }
+            ]
+        }
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(UserCredential.objects.filter(username=username).exists())
+        self.assertEqual(
+            response.data.get('attributes')[1]['namespace'][0],
+            'This field may not be blank.'
+        )
+
+    def test_create_with_existing_usercredential(self):
+        """ Verify that, if a user has already been issued a credential, further
+        attempts to issue the same credential will NOT create a new credential
+        and will NOT modify the existing credential.
+        """
+        username = 'test_user'
+        data = {
+            "username": username,
+            "credential": {
+                "program_id": self.program_id
+            },
+            "attributes": [
+                {
+                    "namespace": "white",
+                    "name": "grade",
+                    "value": "0.5"
+                }
+            ]
+        }
+
+        user_credential_1 = factories.UserCredentialFactory.create(username=username, credential=self.program_cert)
+
+        # 2nd attempt to create credential with attributes.
+        msg = 'User [{username}] already has a credential for program [{program_id}].'.format(
+            username=username,
+            program_id=self.program_id
+        )
+
+        # Verify log is captured.
+        with LogCapture(LOGGER_NAME) as l:
+            response = self._attempt_create_user_credentials(data)
+            l.check((LOGGER_NAME, 'WARNING', msg))
+
+        self.assertEqual(response.status_code, 201)
+        user_credential_2 = UserCredential.objects.get(username=username)
+        self.assertEqual(user_credential_1, user_credential_2)
+
+    def test_list_with_username_filter(self):
+        """ Verify the list endpoint supports filter data by username."""
+        factories.UserCredentialFactory(username="dummy-user")
+        path = self.list_path + "?username=" + self.user_credential.username
+
+        response = self.client.get(path)
+        self.assertEqual(response.status_code, 200)
+
+        # after filtering it is only one related record
+        expected = UserCredentialSerializer(self.user_credential).data
+        self.assertEqual(response.data, {'count': 1, 'next': None, 'previous': None, 'results': [expected]})
+
+    def test_list_with_status_filter(self):
+        """ Verify the list endpoint supports filtering by status."""
+        factories.UserCredentialFactory.create_batch(2, status="revoked", username=self.user_credential.username)
+        path = self.list_path + "?status={}" + self.user_credential.status
+
+        response = self.client.get(path)
+        self.assertEqual(response.status_code, 400)
+
+        # username and status will return the data.
+        path = self.list_path + "?username={user}&status={status}".format(
+            user=self.user_credential.username,
+            status=UserCredential.AWARDED)
+        response = self.client.get(path)
+
+        # after filtering it is only one related record
+        expected = UserCredentialSerializer(self.user_credential).data
+        self.assertEqual(
+            json.loads(response.content),
+            {'count': 1, 'next': None, 'previous': None, 'results': [expected]}
+        )
+
+    def test_create_with_non_existing_credential(self):
+        """ Verify no UserCredential is created, and HTTP 400 is return if credential
+        id does not exists in db.
+        """
+        username = 'test_user'
+        cred_id = 10
+        data = {
+            "username": username,
+            "credential": {
+                "program_id": cred_id
+            },
+            "attributes": [
+            ]
+        }
+
+        msg = "Credential ID [{cred_id}] for [ProgramCertificate matching query does not exist.]".format(
+            cred_id=cred_id
+        )
+
+        # Verify log is captured.
+        with LogCapture(LOGGER_NAME_SERIALIZER) as l:
+            response = self._attempt_create_user_credentials(data)
+            l.check((LOGGER_NAME_SERIALIZER, 'ERROR', msg))
+
+        self.assertEqual(response.status_code, 400)

--- a/credentials/apps/api/v1/urls.py
+++ b/credentials/apps/api/v1/urls.py
@@ -1,3 +1,10 @@
 """ API v1 URLs. """
+from rest_framework.routers import DefaultRouter
 
-urlpatterns = []
+from credentials.apps.api.v1 import views
+
+
+router = DefaultRouter()  # pylint: disable=invalid-name
+router.register(r'user-credentials', views.UserCredentialViewSet)
+
+urlpatterns = router.urls

--- a/credentials/apps/api/v1/views.py
+++ b/credentials/apps/api/v1/views.py
@@ -1,1 +1,35 @@
-# Create your views here.
+"""
+Credentials service API views (v1).
+"""
+import logging
+
+from rest_framework import filters, viewsets
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
+
+from credentials.apps.api.serializers import UserCredentialCreationSerializer, UserCredentialSerializer
+from credentials.apps.credentials.models import UserCredential
+
+
+log = logging.getLogger(__name__)
+
+
+class UserCredentialViewSet(viewsets.ModelViewSet):
+    """ UserCredentials endpoints. """
+
+    queryset = UserCredential.objects.all()
+    filter_backends = (filters.DjangoFilterBackend,)
+    filter_fields = ('username', 'status')
+    serializer_class = UserCredentialSerializer
+    permission_classes = (DjangoModelPermissionsOrAnonReadOnly,)
+
+    def list(self, request, *args, **kwargs):
+        if not self.request.query_params.get('username'):
+            raise ValidationError(
+                {'error': 'A username query string parameter is required for filtering user credentials.'})
+
+        return super(UserCredentialViewSet, self).list(request, *args, **kwargs)  # pylint: disable=maybe-no-member
+
+    def create(self, request, *args, **kwargs):
+        self.serializer_class = UserCredentialCreationSerializer
+        return super(UserCredentialViewSet, self).create(request, *args, **kwargs)

--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -1,0 +1,119 @@
+""" Issuer classes used to generate user credentials."""
+from __future__ import unicode_literals
+
+import abc
+import logging
+
+from django.db import transaction
+from django.contrib.contenttypes.models import ContentType
+from credentials.apps.api.exceptions import DuplicateAttributeError
+
+from credentials.apps.credentials.models import (
+    ProgramCertificate,
+    UserCredentialAttribute, UserCredential
+)
+from credentials.apps.credentials.utils import validate_duplicate_attributes
+
+logger = logging.getLogger(__name__)
+
+
+class AbstractCredentialIssuer(object):
+    """
+    Abstract credential issuer.
+
+    Credential issuers are responsible for taking inputs and issuing a single credential (subclass of
+    AbstractCredential) to a given user.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractproperty
+    def issued_credential_type(self):
+        """
+        Type of credential type to be issued.
+
+        Returns:
+            AbstractCredential
+        """
+        raise NotImplementedError  # pragma: no cover
+
+    @abc.abstractmethod
+    def issue_credential(self, credential, username, attributes=None):
+        """
+        Issue a credential to the user.
+
+        This action is idempotent. If the user has already earned the credential, a new one WILL NOT be issued. The
+        existing credential WILL NOT be modified.
+
+        Arguments:
+            credential (AbstractCredential): Type of credential to issue.
+            username (str): username of user for which credential required
+            attributes (List[dict]): optional list of attributes that should be associated with the issued credential.
+
+        Returns:
+            UserCredential
+        """
+        raise NotImplementedError  # pragma: no cover
+
+    @abc.abstractmethod
+    def set_credential_attributes(self, user_credential, attributes):
+        """
+        Add attributes to the given UserCredential.
+
+        Arguments:
+            user_credential (AbstractCredential): Type of credential to issue.
+            attributes (List[dict]): optional list of attributes that should be associated with the issued credential.
+
+        Raises:
+            In case of duplicate issue it will raise the exception and parent method will rolled back the whole
+            transaction.
+
+        """
+        raise NotImplementedError  # pragma: no cover
+
+
+class ProgramCertificateIssuer(AbstractCredentialIssuer):
+    """ Issues ProgramCertificates. """
+    issued_credential_type = ProgramCertificate
+
+    @transaction.atomic
+    def issue_credential(self, credential, username, attributes=None):
+        user_credential, created = UserCredential.objects.get_or_create(
+            username=username,
+            credential_content_type=ContentType.objects.get_for_model(credential),
+            credential_id=credential.id
+        )
+
+        # if new record created then add its attributes.
+        if created:
+            self.set_credential_attributes(user_credential, attributes)
+
+        # if credential already exists then don't create the record.
+        else:
+            logger.warning("User [%s] already has a credential for program [%s].", username, credential.program_id)
+
+        return user_credential
+
+    def set_credential_attributes(self, user_credential, attributes):
+        if not attributes:
+            return
+
+        if not validate_duplicate_attributes(attributes):
+            raise DuplicateAttributeError("Attributes cannot be duplicated.")
+
+        for attr in attributes:
+            __, created = UserCredentialAttribute.objects.get_or_create(
+                user_credential=user_credential,
+                namespace=attr.get('namespace'),
+                name=attr.get('name'),
+                defaults={'value': attr.get('value')}
+            )
+            if not created:
+                raise DuplicateAttributeError(
+                    u"Attribute with namespace [{namespace}] and name [{name}]"
+                    u" is already added for credential [{id}] with username [{username}]".format(
+                        namespace=attr.get('namespace'),
+                        name=attr.get('name'),
+                        id=user_credential.id,
+                        username=user_credential.username
+                    )
+                )

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -5,8 +5,7 @@ Models for the credentials service.
 from __future__ import unicode_literals
 import uuid  # pylint: disable=unused-import
 
-from django.contrib.contenttypes.fields import GenericForeignKey
-from django.contrib.contenttypes.fields import GenericRelation
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
@@ -37,7 +36,6 @@ def template_assets_path(instance, filename):
     Returns:
         Path to asset.
     """
-
     return 'certificate_template_assets/{id}/{filename}'.format(id=instance.id, filename=filename)
 
 
@@ -161,7 +159,7 @@ class CertificateTemplate(TimeStampedModel):
         )
 
 
-class AbstractCertificate(AbstractCredential):
+class AbstractCertificate(AbstractCredential):  # pylint: disable=abstract-method
     """
     Abstract Certificate configuration to support multiple type of certificates
     i.e. Programs, Courses.

--- a/credentials/apps/credentials/tests/test_issuer.py
+++ b/credentials/apps/credentials/tests/test_issuer.py
@@ -1,0 +1,119 @@
+"""
+Tests for Issuer class.
+"""
+# pylint: disable=no-member
+import ddt
+from django.test import TestCase
+from testfixtures import LogCapture
+from credentials.apps.api.exceptions import DuplicateAttributeError
+
+from credentials.apps.api.tests.factories import ProgramCertificateFactory
+from credentials.apps.credentials.issuers import ProgramCertificateIssuer
+from credentials.apps.credentials.models import (
+    ProgramCertificate,
+    UserCredential,
+    UserCredentialAttribute
+)
+
+
+LOGGER_NAME = 'credentials.apps.credentials.issuers'
+
+
+@ddt.ddt
+class ProgramCertificateIssuerTests(TestCase):
+    """ Tests for Issuer class and its methods."""
+
+    def setUp(self):
+        super(ProgramCertificateIssuerTests, self).setUp()
+        self.issuer = ProgramCertificateIssuer()
+        self.program_certificate = ProgramCertificateFactory.create()
+        self.username = 'tester'
+        self.user_program_cred = self.issuer.issue_credential(self.program_certificate, self.username)
+        self.attributes = [
+            {"namespace": "whitelist1", "name": "grade", "value": "0.5"},
+            {"namespace": "whitelist2", "name": "grade", "value": "0.5"}
+        ]
+
+    def test_issued_credential_type(self):
+        """ Verify issued_credential_type returns the correct credential type."""
+        self.assertEqual(self.issuer.issued_credential_type, ProgramCertificate)
+
+    def test_issue_credential_without_attributes(self):
+        """ Verify credentials can be issued without attributes."""
+
+        user_credential = self.issuer.issue_credential(self.program_certificate, self.username)
+        self._assert_usercredential_fields(user_credential, self.program_certificate, self.username, [])
+
+    def test_issue_credential_with_attributes(self):
+        """ Verify credentials can be issued with attributes."""
+
+        user_credential = self.issuer.issue_credential(self.program_certificate, 'testuser2', self.attributes)
+        self._assert_usercredential_fields(user_credential, self.program_certificate, 'testuser2', self.attributes)
+
+    def test_credential_already_exists(self):
+        """ Verify that credential will not be issued if user has already issued credential."""
+        self.issuer.issue_credential(self.program_certificate, self.username, self.attributes)
+
+        # Create credentials with same information.
+        self.issuer.issue_credential(self.program_certificate, self.username, self.attributes)
+
+        # Verify only one record exists in database.
+        self.assertEqual(UserCredential.objects.all().count(), 1)
+
+        # Verify log is captured.
+        msg = 'User [{username}] already has a credential for program [{program_id}].'.format(
+            username=self.username, program_id=self.program_certificate.program_id)
+        with LogCapture(LOGGER_NAME) as l:
+            self.issuer.issue_credential(self.program_certificate, self.username, self.attributes)
+            l.check((LOGGER_NAME, 'WARNING', msg))
+
+    def _assert_usercredential_fields(self, user_credential, expected_credential, expected_username, expected_attrs):  # pylint: disable=line-too-long
+        """ Verify the fields on a UserCredential object match expectations. """
+        self.assertEqual(user_credential.username, expected_username)
+        self.assertEqual(user_credential.credential, expected_credential)
+        actual_attributes = [
+            {'namespace': attr.namespace, 'name': attr.name, 'value': attr.value}
+            for attr in user_credential.attributes.all()
+        ]
+        self.assertEqual(actual_attributes, expected_attrs)
+
+    def test_set_credential_without_attributes(self):
+        """ Verify that if no attributes given then None will return."""
+        self.assertEqual(
+            self.issuer.set_credential_attributes(self.user_program_cred, None),
+            None
+        )
+
+    def test_set_credential_with_attributes(self):
+        """ Verify that it adds the given attributes against user credential."""
+
+        self.issuer.set_credential_attributes(self.user_program_cred, self.attributes)
+        self._assert_usercredential_fields(
+            self.user_program_cred, self.program_certificate, self.user_program_cred.username, self.attributes
+        )
+
+    def test_set_credential_with_duplicate_attributes_by_util(self):
+        """Verify in case of duplicate attributes utils method will return False and
+        exception will be raised.
+        """
+        self.attributes[0].update({'namespace': 'whitelist2'})
+
+        with self.assertRaises(DuplicateAttributeError):
+            self.issuer.set_credential_attributes(self.user_program_cred, self.attributes)
+
+    def test_set_credential_with_duplicate_attributes_by_db(self):
+        """Verify in case of duplicate attributes if any existing record was in db
+        then exception will be raised.
+        """
+        # add the attribute in db and then try to create the credential
+        # with same data. In this case get_or_create will return False.
+
+        UserCredentialAttribute.objects.create(
+            user_credential=self.user_program_cred,
+            namespace="whitelist1",
+            name="grade",
+            value="0.8"
+        )
+
+        with self.assertRaises(DuplicateAttributeError):
+            self.issuer.set_credential_attributes(self.user_program_cred, self.attributes)

--- a/credentials/apps/credentials/tests/test_models.py
+++ b/credentials/apps/credentials/tests/test_models.py
@@ -13,12 +13,14 @@ from credentials.apps.credentials.models import (
 )
 from credentials.settings.base import MEDIA_ROOT
 
+
 # pylint: disable=invalid-name
 TEST_DATA_ROOT = MEDIA_ROOT + '/test/data/'
 
 
 class TestSignatory(TestCase):
     """Test Signatory model."""
+
     def get_image(self, name):
         """Get one of the test images from the test data directory."""
         return ImageFile(open(TEST_DATA_ROOT + name + '.png'))
@@ -74,6 +76,7 @@ class TestCertificateTemplateAsset(TestCase):
     """
     Test Assets are uploading/saving successfully for CertificateTemplateAsset.
     """
+
     def test_asset_file_saving(self):
         """
         Verify that asset file is saving with actual name and on correct path.
@@ -114,6 +117,7 @@ class TestCertificateTemplate(TestCase):
 
 class TestCertificates(TestCase):
     """Basic setup for certificate tests."""
+
     def setUp(self):
         super(TestCertificates, self).setUp()
         self.site = Site.objects.create(domain='test', name='test')

--- a/credentials/apps/credentials/tests/test_utils.py
+++ b/credentials/apps/credentials/tests/test_utils.py
@@ -1,0 +1,29 @@
+"""
+Tests for Issuer class.
+"""
+import ddt
+from django.test import TestCase
+from credentials.apps.credentials.utils import validate_duplicate_attributes
+
+
+@ddt.ddt
+class ValidateDuplicateAttributesTests(TestCase):
+    """ Tests for Validate the attributes method """
+
+    def test_with_non_duplicate_attributes(self):
+        """ Verify that the method will return True if no duplicated attributes found."""
+        attributes = [
+            {"namespace": "whitelist1", "name": "grades1", "value": "0.9"},
+            {"namespace": "whitelist2", "name": "grades2", "value": "0.7"}
+        ]
+        self.assertTrue(validate_duplicate_attributes(attributes))
+
+    def test_with_duplicate_attributes(self):
+        """ Verify that the method will return False if duplicated attributes found."""
+
+        attributes = [
+            {"namespace": "whitelist1", "name": "grades1", "value": "0.9"},
+            {"namespace": "whitelist1", "name": "grades1", "value": "0.7"}
+        ]
+
+        self.assertFalse(validate_duplicate_attributes(attributes))

--- a/credentials/apps/credentials/utils.py
+++ b/credentials/apps/credentials/utils.py
@@ -1,0 +1,21 @@
+"""
+Helper methods for data validation.
+"""
+from itertools import groupby
+
+
+def validate_duplicate_attributes(attributes):
+    """
+    Validate the attributes data
+
+    Arguments:
+            attributes (list): List of dicts contains attributes data.
+
+    Returns:
+        Boolean: Return True if data has no duplicated namespace and name otherwise False
+
+    """
+    for __, group in groupby(sorted(attributes), lambda x: (x['namespace'], x['name'])):
+        if len(list(group)) > 1:
+            return False
+    return True

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -1,7 +1,9 @@
 import os
 from os.path import join, abspath, dirname
+from credentials.settings.utils import get_logger_config
 
 # PATH vars
+
 here = lambda *x: join(abspath(dirname(__file__)), *x)
 PROJECT_ROOT = here("..")
 root = lambda *x: join(abspath(PROJECT_ROOT), *x)
@@ -14,6 +16,9 @@ SECRET_KEY = os.environ.get('CREDENTIALS_SECRET_KEY', 'insecure-secret-key')
 DEBUG = False
 
 ALLOWED_HOSTS = []
+
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#site-id
+SITE_ID = 1
 
 # Application definition
 
@@ -203,3 +208,13 @@ LOGIN_REDIRECT_URL = '/admin/'
 # OPENEDX-SPECIFIC CONFIGURATION 
 PLATFORM_NAME = 'Your Platform Name Here'
 # END OPENEDX-SPECIFIC CONFIGURATION
+
+# Set up logging for development use (logging to stdout)
+LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
+
+REST_FRAMEWORK = {
+    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 20,
+    'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%SZ'
+}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,8 @@ django-compressor==1.6
 django-extensions==1.6.1
 django-libsass==0.6
 django-waffle==0.11
-djangorestframework==3.3.2
+django-filter==0.11.0
+djangorestframework==3.2.3
 django-rest-swagger==0.3.4
 edx-auth-backends==0.1.3
 pytz==2015.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,8 @@ coverage==4.0.3
 django-dynamic-fixture==1.8.5
 django-nose==1.4.2
 edx-lint==0.4.0
+factory-boy==2.5.2
 mock==1.3.0
 nose-ignore-docstring==0.2
 pep8==1.6.2
+testfixtures==4.2.0


### PR DESCRIPTION
ECOM-2999

* Adding the end-points to create the user credentials.
* Patch functionality to update the status.
* Classes implementation.
* /api/v1/credentials/: List all credentials
* /api/v1/credentials/:id/: Retrieve a single credential
* Added filtering to your list endpoint: /api/v1/credentials/?username=<username>&status=<status>.

Reference: https://github.com/edx/edx-platform/commit/84699260e06199b8a41c3765260dc35cf619e4c1

Filtering for Programs and Courses will be added in separate story [ECOM-3263](https://openedx.atlassian.net/browse/ECOM-3263).