### PR TITLE
use django version '1.8.7' for base requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-django>=1.8.7,<1.9
+django==1.8.7
 django_compressor
 django-extensions
 django-libsass


### PR DESCRIPTION
@awais786 

Update base requirements for django, `django==1.8.7`