### PR TITLE
add debug logger for devstack settings

### DIFF
--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -1,6 +1,10 @@
 from credentials.settings.production import *
+from credentials.settings.logger import get_logger_config
+
 
 DEBUG = True
+
+LOGGING = get_logger_config(debug=True, dev_env=True, local_loglevel='DEBUG')
 
 # TOOLBAR CONFIGURATION
 # See: http://django-debug-toolbar.readthedocs.org/en/latest/installation.html


### PR DESCRIPTION
add debug level logger for `devstack` settings.
@awais786 @ahsan-ul-haq @tasawernawaz @waheedahmed 