### PR TITLE
change url from hyphen to underscore

### DIFF
--- a/credentials/apps/api/v1/urls.py
+++ b/credentials/apps/api/v1/urls.py
@@ -5,6 +5,8 @@ from credentials.apps.api.v1 import views
 
 
 router = DefaultRouter()  # pylint: disable=invalid-name
-router.register(r'user-credentials', views.UserCredentialViewSet)
+# URL can not have hyphen as it is not currently supported by slumber
+# as mentioned https://github.com/samgiles/slumber/issues/44
+router.register(r'user_credentials', views.UserCredentialViewSet)
 
 urlpatterns = router.urls


### PR DESCRIPTION
@clintonb I have tried to fetch the data using this URL in lms [here](https://github.com/edx/edx-platform/pull/11064/files#diff-ad7d61197fa94d2095dccbb82e6ab748R39) but I got error as hyphen is not allowed so I change it. Is that okay or would you suggest something else?
FYI: @awais786 @zubair-arbi 