### PR TITLE
Fixed bug in 'read_only_fields' of credential update API.

### DIFF
--- a/credentials/apps/api/serializers.py
+++ b/credentials/apps/api/serializers.py
@@ -65,8 +65,8 @@ class UserCredentialAttributeSerializer(serializers.ModelSerializer):
 class UserCredentialSerializer(serializers.ModelSerializer):
     """ Serializer for UserCredential objects. """
 
-    credential = CredentialField()
-    attributes = UserCredentialAttributeSerializer(many=True)
+    credential = CredentialField(read_only=True)
+    attributes = UserCredentialAttributeSerializer(many=True, read_only=True)
 
     class Meta(object):
         model = UserCredential
@@ -74,7 +74,7 @@ class UserCredentialSerializer(serializers.ModelSerializer):
             'id', 'username', 'credential', 'status', 'download_url', 'uuid', 'attributes', 'created', 'modified',
         )
         read_only_fields = (
-            'username', 'credential', 'download_url', 'uuid', 'attributes', 'created', 'modified',
+            'username', 'download_url', 'uuid', 'created', 'modified',
         )
 
 

--- a/credentials/apps/api/tests/test_views.py
+++ b/credentials/apps/api/tests/test_views.py
@@ -68,7 +68,9 @@ class UserCredentialViewSetTests(APITestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_partial_update(self):
-        """ Verify the only status field can be updated. """
+        """ Verify that only the 'status' field is updated and other fields
+        value remain same.
+        """
         data = {
             'id': self.user_credential.id,
             'status': UserCredential.REVOKED,
@@ -80,6 +82,8 @@ class UserCredentialViewSetTests(APITestCase):
 
         user_credential = UserCredential.objects.get(id=self.user_credential.id)
         self.assertEqual(user_credential.status, data["status"])
+
+        self.assertNotEqual(user_credential.download_url, data["download_url"])
         self.assertEqual(user_credential.download_url, self.user_credential.download_url)
 
     def test_partial_update_authentication(self):


### PR DESCRIPTION
ECOM-2999

Please review this. I have fixed issue of `read_only_feilds` in user credential update API.
@ahsan-ul-haq @awais786 @zubair-arbi 
