### PR TITLE
Added filter for program and course credentials APIs.

### DIFF
--- a/credentials/apps/api/filters.py
+++ b/credentials/apps/api/filters.py
@@ -1,0 +1,28 @@
+"""
+Reusable queryset filters for the REST API.
+"""
+import django_filters
+from credentials.apps.credentials.models import UserCredential
+
+
+class ProgramFilter(django_filters.FilterSet):
+    """ Allows for filtering program credentials by their program_id and status
+    using a query string argument.
+    """
+    program_id = django_filters.NumberFilter(name="program_credentials__program_id")
+
+    class Meta:
+        model = UserCredential
+        fields = ['program_id', 'status']
+
+
+class CourseFilter(django_filters.FilterSet):
+    """ Allows for filtering course credentials by their course_id, status and
+    certificate_type using a query string argument.
+    """
+    course_id = django_filters.CharFilter(name="course_credentials__course_id")
+    certificate_type = django_filters.CharFilter(name="course_credentials__certificate_type")
+
+    class Meta:
+        model = UserCredential
+        fields = ['course_id', 'status', 'certificate_type']

--- a/credentials/apps/api/v1/urls.py
+++ b/credentials/apps/api/v1/urls.py
@@ -8,5 +8,6 @@ router = DefaultRouter()  # pylint: disable=invalid-name
 # URL can not have hyphen as it is not currently supported by slumber
 # as mentioned https://github.com/samgiles/slumber/issues/44
 router.register(r'user_credentials', views.UserCredentialViewSet)
-
+router.register(r'program_credentials', views.ProgramsCredentialsViewSet, base_name='programcredential')
+router.register(r'course_credentials', views.CourseCredentialsViewSet, base_name='coursecredential')
 urlpatterns = router.urls

--- a/credentials/apps/api/v1/views.py
+++ b/credentials/apps/api/v1/views.py
@@ -3,9 +3,10 @@ Credentials service API views (v1).
 """
 import logging
 
-from rest_framework import filters, viewsets
+from rest_framework import filters, mixins, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
+from credentials.apps.api.filters import ProgramFilter, CourseFilter
 
 from credentials.apps.api.serializers import UserCredentialCreationSerializer, UserCredentialSerializer
 from credentials.apps.credentials.models import UserCredential
@@ -33,3 +34,35 @@ class UserCredentialViewSet(viewsets.ModelViewSet):
     def create(self, request, *args, **kwargs):
         self.serializer_class = UserCredentialCreationSerializer
         return super(UserCredentialViewSet, self).create(request, *args, **kwargs)
+
+
+class ProgramsCredentialsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    """It will return the all credentials for programs."""
+    queryset = UserCredential.objects.all()
+    filter_backends = (filters.DjangoFilterBackend,)
+    filter_class = ProgramFilter
+    serializer_class = UserCredentialSerializer
+
+    def list(self, request, *args, **kwargs):
+        if not self.request.query_params.get('program_id'):
+            raise ValidationError(
+                {'error': 'A program_id query string parameter is required for filtering program credentials.'})
+
+        # pylint: disable=maybe-no-member
+        return super(ProgramsCredentialsViewSet, self).list(request, *args, **kwargs)
+
+
+class CourseCredentialsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    """It will return the all credentials for courses."""
+    queryset = UserCredential.objects.all()
+    filter_backends = (filters.DjangoFilterBackend,)
+    filter_class = CourseFilter
+    serializer_class = UserCredentialSerializer
+
+    def list(self, request, *args, **kwargs):
+        if not self.request.query_params.get('course_id'):
+            raise ValidationError(
+                {'error': 'A course_id query string parameter is required for filtering course credentials.'})
+
+        # pylint: disable=maybe-no-member
+        return super(CourseCredentialsViewSet, self).list(request, *args, **kwargs)

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -229,7 +229,8 @@ class CourseCertificate(AbstractCertificate):
     user_credentials = GenericRelation(
         UserCredential,
         content_type_field='credential_content_type',
-        object_id_field='credential_id'
+        object_id_field='credential_id',
+        related_query_name='course_credentials'
     )
 
     class Meta(object):
@@ -244,7 +245,8 @@ class ProgramCertificate(AbstractCertificate):
     user_credentials = GenericRelation(
         UserCredential,
         content_type_field='credential_content_type',
-        object_id_field='credential_id'
+        object_id_field='credential_id',
+        related_query_name='program_credentials'
     )
 
 


### PR DESCRIPTION
ECOM-3263
Added following filters end points for program and course credentials.

* `/api/v1/program_credentials/?program_id=<program_id>`
* `/api/v1/program_credentials/?program_id=<program_id>&status=<status>`
* `/api/v1/course_credentials/?course_id=<course_id>`
* `/api/v1/course_credentials/?course_id=<course_id>&status=<status>`
* `/api/v1/course_credentials/?course_id=<course_id>&certificate_type=<certificate_type>`

Please review this @zubair-arbi @ahsan-ul-haq @awais786 