### PR TITLE
Removed field namespace from credential attributes

### DIFF
--- a/credentials/apps/api/serializers.py
+++ b/credentials/apps/api/serializers.py
@@ -74,7 +74,7 @@ class UserCredentialAttributeSerializer(serializers.ModelSerializer):
 
     class Meta(object):
         model = UserCredentialAttribute
-        fields = ('namespace', 'name', 'value')
+        fields = ('name', 'value')
 
 
 class UserCredentialSerializer(serializers.ModelSerializer):
@@ -102,7 +102,7 @@ class UserCredentialCreationSerializer(serializers.ModelSerializer):
     certificate_url = UserCertificateURLField(source='uuid')
 
     def validate_attributes(self, data):
-        """ Check that the attributes namespace and name cannot be duplicated."""
+        """ Check that the name attributes cannot be duplicated."""
         if not validate_duplicate_attributes(data):
             raise ValidationError("Attributes cannot be duplicated.")
         return data

--- a/credentials/apps/api/tests/factories.py
+++ b/credentials/apps/api/tests/factories.py
@@ -65,7 +65,6 @@ class UserCredentialAttributeFactory(factory.django.DjangoModelFactory):
         model = models.UserCredentialAttribute
 
     user_credential = factory.SubFactory(UserCredentialFactory)
-    namespace = factory.Sequence(lambda o: u'namespace-%d' % o)
     name = factory.Sequence(lambda o: u'name-%d' % o)
     value = factory.Sequence(lambda o: u'value-%d' % o)
 

--- a/credentials/apps/api/tests/test_accreditors.py
+++ b/credentials/apps/api/tests/test_accreditors.py
@@ -27,7 +27,7 @@ class AccreditorTests(TestCase):
         self.accreditor = Accreditor()
         self.program_cert = ProgramCertificateFactory()
         self.program_credential = ProgramCertificate
-        self.attributes = [{"namespace": "whitelist", "name": "whitelist", "value": "some reason"}]
+        self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
 
     def test_create_credential_type_issuer_map(self):
         """ Verify the Accreditor supports only one issuer per credential type. """

--- a/credentials/apps/api/tests/test_serializers.py
+++ b/credentials/apps/api/tests/test_serializers.py
@@ -52,7 +52,6 @@ class UserCredentialSerializerTests(TestCase):
             "status": self.program_credential.status,
             "attributes": [
                 {
-                    "namespace": self.program_cert_attr.namespace,
                     "name": self.program_cert_attr.name,
                     "value": self.program_cert_attr.value
                 }
@@ -87,7 +86,6 @@ class UserCredentialSerializerTests(TestCase):
             "status": self.course_credential.status,
             "attributes": [
                 {
-                    "namespace": self.course_cert_attr.namespace,
                     "name": self.course_cert_attr.name,
                     "value": self.course_cert_attr.value
                 }
@@ -113,7 +111,6 @@ class UserCredentialAttributeSerializerTests(TestCase):
         """ Verify that user CredentialAttributeSerializer serialize data correctly."""
         serialize_data = serializers.UserCredentialAttributeSerializer(self.program_cert_attr)
         expected = {
-            "namespace": self.program_cert_attr.namespace,
             "name": self.program_cert_attr.name,
             "value": self.program_cert_attr.value
         }

--- a/credentials/apps/api/tests/test_views.py
+++ b/credentials/apps/api/tests/test_views.py
@@ -135,9 +135,8 @@ class UserCredentialViewSetTests(APITestCase):
             "credential": {"program_id": self.program_id},
             "attributes": [
                 {
-                    "namespace": "testing",
-                    "name": "grade",
-                    "value": "0.8"
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
                 }
             ]
         }
@@ -163,9 +162,8 @@ class UserCredentialViewSetTests(APITestCase):
             "credential": {"program_id": self.program_id},
             "attributes": [
                 {
-                    "namespace": "testing",
-                    "name": "grade",
-                    "value": "0.8"
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
                 }
             ]
         }
@@ -187,15 +185,9 @@ class UserCredentialViewSetTests(APITestCase):
             },
             "attributes": [
                 {
-                    "namespace": self.user_credential_attribute.namespace,
                     "name": self.user_credential_attribute.name,
                     "value": self.user_credential_attribute.value
                 },
-                {
-                    "namespace": "testing",
-                    "name": "grade",
-                    "value": "0.8"
-                }
             ]
         }
         response = self._attempt_create_user_credentials(data)
@@ -224,24 +216,20 @@ class UserCredentialViewSetTests(APITestCase):
             "credential": {"program_id": self.program_id},
             "attributes": [
                 {
-                    "namespace": "white",
-                    "name": "grade",
-                    "value": "0.5"
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
                 },
                 {
-                    "namespace": "dummyspace",
-                    "name": "grade",
-                    "value": "0.6"
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
                 },
                 {
-                    "namespace": "white",
-                    "name": "grade",
-                    "value": "0.8"
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
                 },
                 {
-                    "namespace": "white",
-                    "name": "grade",
-                    "value": "0.8"
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
                 }
             ]
         }
@@ -261,14 +249,12 @@ class UserCredentialViewSetTests(APITestCase):
             "credential": {"program_id": self.program_id},
             "attributes": [
                 {
-                    "namespace": "white",
-                    "name": "grade",
-                    "value": "0.5"
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
                 },
                 {
-                    "namespace": "",
-                    "name": "grade",
-                    "value": "0.8"
+                    "name": "",
+                    "value": "Reason for whitelisting."
                 }
             ]
         }
@@ -276,7 +262,7 @@ class UserCredentialViewSetTests(APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertFalse(UserCredential.objects.filter(username=self.username).exists())
         self.assertEqual(
-            response.data.get('attributes')[1]['namespace'][0],
+            response.data.get('attributes')[1]['name'][0],
             'This field may not be blank.'
         )
 
@@ -344,8 +330,8 @@ class UserCredentialViewSetTests(APITestCase):
         but its attributes will be updated if provided.
         """
         attributes = [
-            {"namespace": "whitelist", "name": "Program whitelist user", "value": "Reason for whitelisting."},
-            {"namespace": "grade", "name": "Final grade", "value": "0.5"}
+            {"name": "whitelist_reason", "value": "Reason for whitelisting."},
+            {"name": "grade", "value": "0.85"}
         ]
 
         data = {
@@ -372,10 +358,10 @@ class UserCredentialViewSetTests(APITestCase):
         self._assert_usercredential_fields(response, self.username, attributes)
 
     @ddt.data(
-        [{"namespace": "grade", "name": "Final grade", "value": "0.5"}],
+        [{"name": "whitelist_reason", "value": "Reason for whitelisting."}],
         [
-            {"namespace": "grade", "name": "Final grade", "value": "0.9"},
-            {"namespace": "grade", "name": "MidTerm grade", "value": "0.5"}
+            {"name": "whitelist_reason", "value": "Reason for whitelisting."},
+            {"name": "grade", "value": "0.85"},
         ],
     )
     def test_create_with_duplicate_attrs(self, attributes):
@@ -388,7 +374,7 @@ class UserCredentialViewSetTests(APITestCase):
             credential=self.program_cert
         )
         factories.UserCredentialAttributeFactory(
-            user_credential=user_credential, namespace="grade", name="Final grade", value="0.75"
+            user_credential=user_credential, name="whitelist_reason", value="Reason for whitelisting."
         )
         self.assertTrue(user_credential.attributes.exists())
 
@@ -417,10 +403,7 @@ class UserCredentialViewSetTests(APITestCase):
             ).data)
         )
 
-        actual_attributes = [
-            {"namespace": attr.namespace, "name": attr.name, "value": attr.value}
-            for attr in user_credential[0].attributes.all()
-        ]
+        actual_attributes = [{"name": attr.name, "value": attr.value} for attr in user_credential[0].attributes.all()]
         self.assertEqual(actual_attributes, expected_attrs)
 
 

--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -92,7 +92,6 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
         for attr in attributes:
             UserCredentialAttribute.objects.update_or_create(
                 user_credential=user_credential,
-                namespace=attr.get('namespace'),
                 name=attr.get('name'),
                 defaults={'value': attr.get('value')}
             )

--- a/credentials/apps/credentials/migrations/0001_initial.py
+++ b/credentials/apps/credentials/migrations/0001_initial.py
@@ -114,7 +114,6 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, verbose_name='created')),
                 ('modified', django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified')),
-                ('namespace', models.CharField(max_length=255)),
                 ('name', models.CharField(max_length=255)),
                 ('value', models.CharField(max_length=255)),
                 ('user_credential', models.ForeignKey(related_name='attributes', to='credentials.UserCredential')),
@@ -152,7 +151,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='usercredentialattribute',
-            unique_together=set([('user_credential', 'namespace', 'name')]),
+            unique_together=set([('user_credential', 'name')]),
         ),
         migrations.AlterUniqueTogether(
             name='usercredential',

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -255,12 +255,11 @@ class UserCredentialAttribute(TimeStampedModel):
     Different attributes of User's Credential such as white list, grade etc.
     """
     user_credential = models.ForeignKey(UserCredential, related_name='attributes')
-    namespace = models.CharField(max_length=255)
     name = models.CharField(max_length=255)
     value = models.CharField(max_length=255)
 
     class Meta(object):
-        unique_together = (('user_credential', 'namespace', 'name'),)
+        unique_together = (('user_credential', 'name'),)
 
 
 class CertificateTemplateAsset(TimeStampedModel):

--- a/credentials/apps/credentials/tests/test_issuer.py
+++ b/credentials/apps/credentials/tests/test_issuer.py
@@ -27,10 +27,7 @@ class ProgramCertificateIssuerTests(TestCase):
         self.program_certificate = ProgramCertificateFactory.create()
         self.username = 'tester'
         self.user_program_cred = self.issuer.issue_credential(self.program_certificate, self.username)
-        self.attributes = [
-            {"namespace": "grade", "name": "FinalTerm", "value": "0.5"},
-            {"namespace": "grade", "name": "MidTerm", "value": "0.6"}
-        ]
+        self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
 
     def test_issued_credential_type(self):
         """ Verify issued_credential_type returns the correct credential type."""
@@ -52,10 +49,7 @@ class ProgramCertificateIssuerTests(TestCase):
         """ Verify the fields on a UserCredential object match expectations. """
         self.assertEqual(user_credential.username, expected_username)
         self.assertEqual(user_credential.credential, expected_credential)
-        actual_attributes = [
-            {'namespace': attr.namespace, 'name': attr.name, 'value': attr.value}
-            for attr in user_credential.attributes.all()
-        ]
+        actual_attributes = [{'name': attr.name, 'value': attr.value} for attr in user_credential.attributes.all()]
         self.assertEqual(actual_attributes, expected_attrs)
 
     def test_set_credential_without_attributes(self):
@@ -77,7 +71,8 @@ class ProgramCertificateIssuerTests(TestCase):
         """Verify in case of duplicate attributes utils method will return False and
         exception will be raised.
         """
-        self.attributes[0].update({"name": "MidTerm"})
+
+        self.attributes.append({"name": "whitelist_reason", "value": "Reason for whitelisting."})
 
         with self.assertRaises(DuplicateAttributeError):
             self.issuer.set_credential_attributes(self.user_program_cred, self.attributes)
@@ -87,13 +82,12 @@ class ProgramCertificateIssuerTests(TestCase):
         update existing attributes values."""
 
         # add the attribute in db and then try to create the credential
-        # with same data "namespace and grade are same but value is different"
+        # with same data "names but value is different"
 
-        attribute_db = {"namespace": "grade", "name": "FinalTerm", "value": "0.3"}
+        attribute_db = {"name": "whitelist_reason", "value": "Reason for whitelisting."}
 
         UserCredentialAttribute.objects.create(
             user_credential=self.user_program_cred,
-            namespace=attribute_db.get("namespace"),
             name=attribute_db.get("name"),
             value=attribute_db.get("value")
         )

--- a/credentials/apps/credentials/tests/test_utils.py
+++ b/credentials/apps/credentials/tests/test_utils.py
@@ -13,8 +13,8 @@ class ValidateDuplicateAttributesTests(TestCase):
     def test_with_non_duplicate_attributes(self):
         """ Verify that the method will return True if no duplicated attributes found."""
         attributes = [
-            {"namespace": "whitelist1", "name": "grades1", "value": "0.9"},
-            {"namespace": "whitelist2", "name": "grades2", "value": "0.7"}
+            {"name": "whitelist_reason", "value": "Reason for whitelisting."},
+            {"name": "grade", "value": "0.85"}
         ]
         self.assertTrue(validate_duplicate_attributes(attributes))
 
@@ -22,8 +22,8 @@ class ValidateDuplicateAttributesTests(TestCase):
         """ Verify that the method will return False if duplicated attributes found."""
 
         attributes = [
-            {"namespace": "whitelist1", "name": "grades1", "value": "0.9"},
-            {"namespace": "whitelist1", "name": "grades1", "value": "0.7"}
+            {"name": "whitelist_reason", "value": "Reason for whitelisting."},
+            {"name": "whitelist_reason", "value": "Reason for whitelisting."},
         ]
 
         self.assertFalse(validate_duplicate_attributes(attributes))

--- a/credentials/apps/credentials/utils.py
+++ b/credentials/apps/credentials/utils.py
@@ -12,11 +12,11 @@ def validate_duplicate_attributes(attributes):
             attributes (list): List of dicts contains attributes data.
 
     Returns:
-        Boolean: Return True if data has no duplicated namespace and name otherwise False
+        Boolean: Return True if data has no duplicate names otherwise False
 
     """
     def keyfunc(attribute):  # pylint: disable=missing-docstring
-        return attribute['namespace'], attribute['name']
+        return attribute['name']
 
     sorted_data = sorted(attributes, key=keyfunc)
     for __, group in groupby(sorted_data, key=keyfunc):

--- a/docs/credentials_api.rst
+++ b/docs/credentials_api.rst
@@ -33,14 +33,8 @@ To create a user credential for a program, use ``user_credentials``.
         "status": "awarded"
         "attributes": [
             {
-                "namespace": "whitelist",
-                "name": "Whitelist",
+                "name": "whitelist_reason",
                 "value": "Your reason for whitelisting."
-            },
-            {
-                "namespace": "grade",
-                "name": "Final Grade",
-                "value": "0.85"
             }
         ]
     }
@@ -122,14 +116,8 @@ To get information about a specific credential for a single user, use ``credenti
         "uuid": "a2810ab0-c084-43de-a9db-fa484fcc82bc",
         "attributes": [
             {
-                "namespace": "whitelist",
-                "name": "Whitelist",
+                "name": "whitelist_reason",
                 "value": "Your reason for whitelisting."
-            },
-            {
-                "namespace": "grade",
-                "name": "Final Grade",
-                "value": "0.85"
             }
         ],
         "created": "2015-12-17T09:28:35.075376Z",
@@ -183,8 +171,7 @@ or ``status`` parameters in the query string.
                 "uuid": "a2810ab0-c084-43de-a9db-fa484fcc82bc",
                 "attributes": [
                     {
-                        "namespace": "whitelist",
-                        "name": "Whitelist",
+                        "name": "whitelist_reason",
                         "value": "Your reason for whitelisting."
                     }
                 ],
@@ -247,8 +234,7 @@ string.
                 "uuid": "bbed53ff-9d5f-4bf0-9289-2fe94fda4363",
                 "attributes": [
                     {
-                        "namespace": "whitelist",
-                        "name": "Whitelist",
+                        "name": "whitelist_reason",
                         "value": "Your reason for whitelisting."
                     }
                 ],
@@ -307,8 +293,7 @@ the ``program_id`` or ``status`` parameters in the query string.
                 "uuid": "a2810ab0-c084-43de-a9db-fa484fcc82bc",
                 "attributes": [
                     {
-                        "namespace": "whitelist",
-                        "name": "Whitelist",
+                        "name": "whitelist_reason",
                         "value": "Your reason for whitelisting."
                     }
                 ],


### PR DESCRIPTION
ECOM-3418

* Removed field `namespace` from credentials attributes.
* Updated relevant tests.
* Added migration.

Please review this @zubair-arbi @ahsan-ul-haq @awais786 