### PR TITLE
Adding HTML for credential rendering.

### DIFF
--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -6,9 +6,10 @@ import logging
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView
+from django.utils.translation import ugettext_lazy as _
 
 from credentials.apps.credentials.models import UserCredential, ProgramCertificate
-from credentials.apps.credentials.utils import get_organization, get_program
+from credentials.apps.credentials.utils import get_organization, get_program, get_user
 
 
 logger = logging.getLogger(__name__)
@@ -50,9 +51,11 @@ class RenderCredential(TemplateView):
         """
         programs_data = self._get_program_data(user_credential.credential.program_id)
         return {
+            'credential_type': _(u'XSeries Certificate'),
+            'user_data': get_user(user_credential.username),
             'programs_data': programs_data,
             'organization_data': get_organization(programs_data['organization_key']),
-            'credential_template': 'credentials/program_certificate.html'
+            'credential_template': 'credentials/program_certificate.html',
         }
 
     def _get_program_data(self, program_id):
@@ -66,6 +69,7 @@ class RenderCredential(TemplateView):
         """
         program_data = get_program(program_id)
         return {
+            'name': program_data['name'],
             'course_count': len(program_data['course_codes']),
             'organization_key': program_data['organizations'][0]['key'],
             'category': program_data['category'],

--- a/credentials/static/js/credentials/print.js
+++ b/credentials/static/js/credentials/print.js
@@ -1,0 +1,12 @@
+require([
+        'jquery'
+    ],
+    function ($) {
+        'use strict';
+
+        $('#action-print-view').click(function (event) {
+            event.preventDefault();
+            window.print();
+        });
+    }
+);

--- a/credentials/templates/base.html
+++ b/credentials/templates/base.html
@@ -12,10 +12,6 @@
     <title>{% block title %}{% endblock title %}</title>
 
     {% compress css %}
-        <link rel="stylesheet" href="{% static 'sass/main-ltr.scss' %}" type="text/x-scss">
-    {% endcompress %}
-
-    {% compress css %}
         {# This block is separated to better support browser caching. #}
         {% block stylesheets %}
         {% endblock %}

--- a/credentials/templates/credentials/base.html
+++ b/credentials/templates/credentials/base.html
@@ -1,0 +1,17 @@
+{# Base template for credentials-specific pages. #}
+{% extends 'base.html' %}
+{% load compress %}
+{% load i18n %}
+{% load staticfiles %}
+{% block title %} {{ certificate_context.credential_type }} | {{ platform_name }}{% endblock title %}
+
+{% block stylesheets %}
+    <link rel="stylesheet" href="{% static 'sass/main-ltr.scss' %}" type="text/x-scss">
+{% endblock %}
+
+{% block content %}
+{% endblock %}
+
+{% block javascript %}
+    <script src="{% static 'js/credentials/print.js' %}"></script>
+{% endblock %}

--- a/credentials/templates/credentials/program_certificate.html
+++ b/credentials/templates/credentials/program_certificate.html
@@ -1,19 +1,223 @@
 {% load i18n %}
-{% block title %}
-        {% trans "XSeries Certificate" %} | {{ platform_name }}
-{% endblock %}
-
+{% load staticfiles %}
 {% block content %}
-    {{ certificate_context.programs_data.course_count }}
-    {{ certificate_context.programs_data.organization_key }}
-    {{ certificate_context.programs_data.category }}
+    <body class="layout-accomplishment view-valid-accomplishment ltr certificate certificate-xseries" data-view="valid-accomplishment">
 
-    {{ certificate_context.organization_data.name }}
-    {{ certificate_context.organization_data.short_name }}
-    {{ certificate_context.organization_data.description }}
-    {{ certificate_context.organization_data.logo }}
+    <div class="wrapper-view" dir="ltr">
 
-    {{ user_credential.username }}
-    {{ user_credential.modified|date:"F d, Y" }}
-    {{ user_credential.uuid }}
+        <div class="wrapper-header">
+            <header class="header-app" role="banner">
+                <h1 class="header-app-title">
+                    <a class="logo" href="{{ certificate_context.organization_data.logo }}">
+                        <img class="logo-img" src="{{ certificate_context.organization_data.logo }}" alt="{{ platform_name }} {% trans 'Home' %}" />
+                    </a>
+                    <span class="sr-only">{{ certificate_context.organization_data.name }}</span>
+                </h1>
+            </header>
+        </div>
+
+        <hr class="divider sr-only">
+        <div id="fb-root"></div>
+
+        <div class="wrapper-banner wrapper-banner-user">
+            <section class="banner banner-user">
+                <div class="message message-block message-notice">
+                    <div class="message-text">
+                        <h2 class="message-title">
+                            {% blocktrans with user_name=certificate_context.user_data.name %}
+                                Congratulations, {{ user_name }}!
+                            {% endblocktrans %}
+                        </h2>
+
+                        <p class="message-copy">
+                            {% blocktrans with organization_name=certificate_context.organization_data.name %}
+                                You worked hard to earn your XSeries certificate from {{ organization_name }}.
+                            {% endblocktrans %}
+                        </p>
+                    </div>
+                    <div class="message-actions">
+                        <div class="message-actions-box">
+                            <h3 class="sr-only">{% trans "Print or share your certificate:" %}</h3>
+                            <button title="{% trans 'Print' %}" class="action action-print btn icon-only" id="action-print-view">
+                                <i class="icon fa fa-print icon-print" aria-hidden="true"></i>
+                                <span class="action-label">{% trans "Print this certificate" %}</span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+
+        <main class="accomplishment accomplishment-main">
+
+            <div class="wrapper-accomplishment-rendering">
+                <div class="accomplishment-rendering">
+                    <div class="wrapper-accomplishment-title xseries">
+                        <h2 class="accomplishment-title">
+                            <span class="accomplishment-title-label">{% trans "XSeries" %}</span>
+                            <span class="accomplishment-title-type">
+                                {% blocktrans with span_start='<span class="deco">' span_end='</span>' %}
+                                    Certificate {{ span_start }} of {{ span_end }} Achievement
+                                {% endblocktrans %}
+                            </span>
+                        </h2>
+
+                        <div class="wrapper-accomplishment-orgs">
+                            <h3 class="accomplishment-orgs-title sr-only">
+                                {% trans "Supported by the following organizations" %}
+                            </h3>
+                            <ul class="wrapper-orgs list-orgs">
+                                <li class="wrapper-organization">
+                                    <div class="organization">
+                                        {% if certificate_context.organization_data and certificate_context.organization_data.logo %}
+                                            <img class="organization-logo" src="{{ certificate_context.organization_data.logo }}" alt="{{ certificate_context.organization_data.name }} {% trans 'logo' %}">
+                                        {% else %}
+                                            <h4 class="organization-name">{{ certificate_context.organization_data.name }}</h4>
+                                        {% endif %}
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="wrapper-accomplishment-statement">
+                        <div class="accomplishment-statement">
+                            <p class="accomplishment-statement-lead">
+                                {% blocktrans with user_name=certificate_context.user_data.name  %}
+                                    <span class="accomplishment-statement-detail copy">This is to certify that</span>
+                                    <strong class="accomplishment-recipient">{{ user_name }}</strong>
+                                    <span class="accomplishment-summary copy">successfully completed all courses in the XSeries Program</span>
+                                {% endblocktrans %}
+                                <span class="accomplishment-program">
+                                    <span class="accomplishment-program-name">{{ certificate_context.programs_data.name }}</span>
+                                </span>
+
+                                <span class="accomplishment-statement-detail copy">
+                                    {# Translators: course_count is an integer value, and name is the display name for the provided organization e.g Test Organization. #}
+                                    {% blocktrans with course_count=certificate_context.programs_data.course_count name=certificate_context.organization_data.name platform_name=platform_name %}
+                                        a series of {{ course_count }} courses offered by {{ name }} through {{ platform_name }}.
+                                    {% endblocktrans %}
+                                </span>
+                            </p>
+                        </div>
+                        <div class="accomplishment-signatories">
+                            <h3 class="accomplishment-signatories-title sr-only">{% trans "Noted by" %}</h3>
+
+                            <div class="wrapper-signatories">
+                                <div class="list-signatories">
+                                    {% for signatory in user_credential.credential.signatories.all %}
+                                    <div class="signatory">
+                                        {% if signatory.image %}
+                                            <img class="signatory-signature" src="{{signatory.image.url}}" alt="{{signatory.name}}">
+                                        {% endif %}
+                                        <h4 class="signatory-name">{{ signatory.name }}</h4>
+
+                                        <p class="signatory-credentials">
+                                            <span class="role">{{ signatory.title }}</span>
+                                            <span class="organization">{{ certificate_context.organization_data.name }}</span>
+                                        </p>
+                                    </div>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="wrapper-accomplishment-stamps">
+                        <ul class="accomplishment-stamps copy-list">
+                            <li class="accomplishment-stamp-platform">
+                                <a class="img-link" href="http://edx.org">
+                                    <img class="logo-img" src="{% static 'images/logo-edX.png' %}" alt="{{ platform_name }}"/>
+                                </a>
+                            </li>
+                            <li class="accomplishment-stamp-date">
+                                <span class="title">{{ certificate_context.credential_type }}</span>
+                                <span class="copy-micro emphasized">{% trans "Issued " %} {{ user_credential.modified|date:"F Y" }}</span>
+                            </li>
+                            <li class="accomplishment-stamp-validity">
+                                <span class="title">{% trans "Valid Certificate ID" %}</span>
+                                <span class="emphasized">{{ user_credential.uuid.hex }}</span>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            <div class="wrapper-accomplishment-support">
+                <div class="accomplishment-support">
+                    <div class="accomplishment-support-print">
+                        <p class="support-copy">
+                            {% blocktrans with link_start='<a href="http://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/SFD_certificates.html#web-certificates">' link_end='</a>' %}
+                                For tips and tricks on printing your certificate, view the
+                                {{ link_start}}  Web Certificates help documentation {{ link_end }}.
+                            {% endblocktrans %}
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="wrapper-accomplishment-metadata">
+                <div class="accomplishment-metadata">
+                    <div class="accomplishment-metadata-bit accomplishment-metadata-aboutedx">
+                        <h3 class="accomplishment-metadata-title">{% trans "About edX" %}</h3>
+
+                        <p class="accomplishment-metadata-copy">
+                            {% blocktrans with link_start='<a href="http://www.edx.org">' link_end='</a>' platform_name=platform_name %}
+                                {{ link_start }} {{ platform_name }} {{ link_end }}
+                                offers interactive online classes and MOOCs from the world’s best universities,
+                                including MIT, Harvard, Berkeley, University of Texas, and many others. {{ platform_name }} is a non-profit
+                                online initiative created by founding partners Harvard and MIT.
+                            {% endblocktrans %}
+                        </p>
+                    </div>
+
+                    <div class="accomplishment-metadata-bit accomplishment-metadata-aboutcert">
+                        <h3 class="accomplishment-metadata-title">{% trans "About edX XSeries Certificates" %}</h3>
+
+                        <p class="accomplishment-metadata-copy">
+                            {% blocktrans with link_start='<a href="http://www.edx.org/verified-certificate">' link_end='</a>' platform_name=platform_name %}
+                                An {{ platform_name }} XSeries certificate signifies that the learner has completed a group of courses that
+                                add up to a rich understanding of an area of study. To complete an XSeries Program, learners
+                                must earn {{ link_start }}Verified Certificates{{ link_end }} from
+                                each of the courses included in the series.
+                            {% endblocktrans %}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </main>
+
+        <hr class="divider sr-only">
+
+        <div class="wrapper-footer">
+            <footer class="footer-app" role="contentinfo" id="company-info">
+                <div class="footer-app-legal">
+                    <nav class="footer-app-nav">
+                        <ul class="list list-legal">
+                            <li class="nav-item">
+                                {% blocktrans with link_start='<a class="action" href="https://www.edx.org/edx-terms-service">' link_end='</a>' %}
+                                    {{ link_start }}Terms of Service &amp; Honor Code
+                                {% endblocktrans %}
+                            </li>
+                            <li class="nav-item">
+                                {% blocktrans with link_start='<a class="action" href="https://www.edx.org/edx-privacy-policy">' link_end='</a>' %}
+                                    {{ link_start }} Privacy Policy {{ link_end }}
+                                {% endblocktrans %}
+                            </li>
+                        </ul>
+                    </nav>
+                    <div class="copyright-trademarks">
+                        <p class="copy">
+                            <span class="copyright">&copy;
+                                <a href="http://www.edx.org">{% trans "edX Inc." %}</a>
+                            </span>
+                            {% trans "All rights reserved except where noted. edX, Open edX and the edX and Open edX logos are registered trademarks or trademarks of edX Inc." %}
+                        </p>
+                    </div>
+                </div>
+                <div class="footer-app-related">
+                    <a class="img-link" href="http://edx.org/about"><img class="logo-img logo-openedx" src="{% static 'images/edx-openedx-logo-tag.png' %}" alt="{% trans 'Powered by Open edX' %}"/></a>
+                </div>
+            </footer>
+        </div>
+    </div>
+</body>
 {% endblock %}

--- a/credentials/templates/credentials/render_credential.html
+++ b/credentials/templates/credentials/render_credential.html
@@ -1,4 +1,5 @@
-{% extends 'base.html' %}
+{% extends 'credentials/base.html' %}
+{% load i18n %}
 
 {% block content %}
     {% include certificate_context.credential_template %}


### PR DESCRIPTION
ECOM-3284
* Adding base template for credentials.
* Add the updated HTML from webcert for XSeries certificates. 
* Adding dynamic values from db and relevant apis e.g organization api, programs api, users api.

HTML is picked from this repo
https://github.com/edx/web-certificates/blob/master/templates/xseries-base.html

Credential Template
<img width="1271" alt="screen shot 2016-01-22 at 7 08 56 pm" src="https://cloud.githubusercontent.com/assets/445320/12512708/a6c228c6-c13b-11e5-8645-a0da44177e18.png">

Print version
<img width="682" alt="screen shot 2016-01-22 at 7 09 04 pm" src="https://cloud.githubusercontent.com/assets/445320/12512728/bda402e4-c13b-11e5-9d36-6541cafa0d2d.png">

