### PR TITLE
Increased verbosity of static files commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ quality:
 
 static:
 	$(NODE_BIN)/r.js -o build.js
-	python manage.py collectstatic --noinput -v0
-	python manage.py compress -v0
+	python manage.py collectstatic --noinput
+	python manage.py compress
 
 validate_js:
 	rm -rf coverage


### PR DESCRIPTION
Limited output may be nice for local development, but is frustrating for failed runs non-development environments. Developers can live with extra output.