### PR TITLE
add default css filter in base settings

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -138,6 +138,7 @@ COMPRESS_OFFLINE = True
 
 # Minify CSS
 COMPRESS_CSS_FILTERS = [
+    'compressor.filters.css_default.CssAbsoluteFilter',
     'compressor.filters.cssmin.CSSMinFilter',
 ]
 # END STATIC FILE CONFIGURATION


### PR DESCRIPTION
@awais786 @ahsan-ul-haq @tasawernawaz 
Add default css filter `CssAbsoluteFilter` from django compressor to base settings to resolve the issue of bower static files paths in css on production.