### PR TITLE
python mamcache version update

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,6 @@ django-storages==1.1.8
 edx-auth-backends==0.1.3
 edx-rest-api-client==1.4.0
 Pillow==3.0.0
-python-memcached==1.48
+python-memcached==1.57
 pytz==2015.7
 git+https://github.com/edx/opaque-keys.git@9f07da1abf699d10bc3252d3081017e8aa37c302#egg=opaque-keys


### PR DESCRIPTION
Update python memcache version as previous version was causing error while compression. 
Here is error 
```python
1216 static files copied to '/edx/var/credentials/staticfiles', 83 unmodified.
python manage.py compress
Found 'compress' tags in:
	/edx/app/credentials/credentials/credentials/templates/credentials/base.html
	/edx/app/credentials/credentials/credentials/templates/credentials/render_credential.html
	/edx/app/credentials/credentials/credentials/templates/base.html
Compressing... CommandError: An error occurred during rendering /edx/app/credentials/credentials/credentials/templates/credentials/base.html: int() argument must be a string or a number, not 'NoneType'

```
@zubair-arbi @tasawernawaz @tasawernawaz 