### PR TITLE
add basic templates for 404 and 500 pages

### DIFF
--- a/credentials/apps/core/tests/test_views.py
+++ b/credentials/apps/core/tests/test_views.py
@@ -1,9 +1,11 @@
 """Test core.views."""
 
+import sys
+
 from django.db import DatabaseError
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import clear_url_caches, reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 import mock
@@ -74,3 +76,26 @@ class AutoAuthTests(TestCase):
 
         # Verify that the user has superuser permissions
         self.assertTrue(user.is_superuser)
+
+
+class SiteViewTests(TestCase):
+    """ Tests for the base site views."""
+
+    def _reload_urlconf(self):
+        """ Helper method to reload url config."""
+        reload(sys.modules[settings.ROOT_URLCONF])
+        clear_url_caches()
+
+    @override_settings(DEBUG=True)
+    def test_500(self):
+        """
+        Test the 500 view.
+        """
+        # Since the the url for the custom 500 view is included only for debug
+        # mode so we need to set the debug mode and reload the django urls
+        # config for adding the 500 view url
+        self._reload_urlconf()
+
+        response = self.client.get(reverse('500'))
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('Server Error', response.content)

--- a/credentials/apps/core/views.py
+++ b/credentials/apps/core/views.py
@@ -7,10 +7,11 @@ from django.http import JsonResponse
 from django.conf import settings
 from django.contrib.auth import get_user_model, login, authenticate
 from django.http import Http404
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render_to_response
 from django.views.generic import View
 
 from credentials.apps.core.constants import Status
+
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
@@ -84,3 +85,18 @@ class AutoAuth(View):
         login(request, user)
 
         return redirect('/')
+
+
+def render_500(request, template_name='500.html'):
+    """ Custom 500 error handler.
+
+    Arguments:
+        template_name (template): Template for rendering
+    """
+    context = {
+        'site': request.site,
+        'platform_name': settings.PLATFORM_NAME,
+    }
+    response = render_to_response(template_name, context)
+    response.status_code = 500
+    return response

--- a/credentials/templates/404.html
+++ b/credentials/templates/404.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load staticfiles %}
+
+{% block title %} {% trans "Page Not Found" %} | {% firstof site.name platform_name %}{% endblock title %}
+
+{% block wrapper_content %}
+    <div>
+        <h1>{% trans "Page Not Found" %}</h1>
+    </div>
+{% endblock %}

--- a/credentials/templates/500.html
+++ b/credentials/templates/500.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load staticfiles %}
+
+{% block title %} {% trans "Server Error" %} | {% firstof site.name platform_name %}{% endblock title %}
+
+{% block wrapper_content %}
+    <div>
+        <h1>{% trans "Server Error" %}</h1>
+    </div>
+{% endblock %}

--- a/credentials/templates/base.html
+++ b/credentials/templates/base.html
@@ -14,11 +14,18 @@
     {% compress css %}
         {# This block is separated to better support browser caching. #}
         {% block stylesheets %}
+            <link rel="stylesheet" href="{% static 'sass/main-ltr.scss' %}" type="text/x-scss">
         {% endblock %}
     {% endcompress %}
 </head>
-<body>
+<body class="ltr">
 {% block content %}
+    <div class="wrapper-view" dir="ltr">
+        {% include "header.html" %}
+
+        {% block wrapper_content %}
+        {% endblock wrapper_content %}
+    </div>
 {% endblock content %}
 
 {# Translation support for JavaScript strings. #}

--- a/credentials/templates/header.html
+++ b/credentials/templates/header.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+{% load staticfiles %}
+
+<div class="wrapper-header">
+    <header class="header-app" role="banner">
+        <h1 class="header-app-title">
+            <a class="logo" href="{{ site.siteconfiguration.lms_url_root }}">
+                <img class="logo-img" src="{% static 'images/logo-edX.png' %}" alt="{% firstof site.name platform_name %}"/>
+            </a>
+            <span class="sr-only">{% firstof site.name platform_name %}</span>
+        </h1>
+    </header>
+</div>

--- a/credentials/urls.py
+++ b/credentials/urls.py
@@ -48,9 +48,15 @@ urlpatterns = [
     url('', include('social.apps.django_app.urls', namespace='social')),
 ]
 
+handler500 = 'credentials.apps.core.views.render_500'
+
 # Add media and extra urls
 if settings.DEBUG:  # pragma: no cover
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns += [
+        url(r'^404/$', 'django.views.defaults.page_not_found', name='404'),
+        url(r'^500/$', handler500, name='500'),
+    ]
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
     import debug_toolbar  # pylint: disable=import-error, wrong-import-position, wrong-import-order


### PR DESCRIPTION
ECOM-3527
@awais786 @ahsan-ul-haq @tasawernawaz 
* add `404.html` page 
* add `500.html` page 
* add urls for 404 and 500 pages
<img width="589" alt="screen shot 2016-01-28 at 3 00 24 pm" src="https://cloud.githubusercontent.com/assets/5072991/12641193/f4e223d8-c5cf-11e5-8e05-d1b5a4e08306.png">
<img width="588" alt="screen shot 2016-01-28 at 3 00 05 pm" src="https://cloud.githubusercontent.com/assets/5072991/12641206/0874de40-c5d0-11e5-87bb-b1b3d3aa96de.png">
