### PR TITLE
add version for libsass

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,9 @@ django-rest-swagger==0.3.4
 django-storages==1.1.8
 edx-auth-backends==0.1.3
 edx-rest-api-client==1.4.0
+# The package django-libsass requires libsass and the newest version of libsass '0.10.1'
+# gives validation error on importing scss variables in scss files
+libsass==0.10.0
 Pillow==3.0.0
 python-memcached==1.57
 pytz==2015.7


### PR DESCRIPTION
@awais786 @ahsan-ul-haq @tasawernawaz 
* add version for libsass `libsass==0.10.0`

_Background: The setup of `django-libsass` requires `"libsass>=0.7.0"` and the newest version `libsass==0.10.1` gives validation error on importing variables in scss files:_
```
Compressing... CommandError: An error occurred during rendering /Users/zubairafzal1/Workspace/devstack/credentials/credentials/templates/credentials/base.html: Error: Import directives may not be used within control directives or mixins.
        on line 12 of credentials/static/sass/_lib.scss
>>     @import '../bower_components/bi-app-sass/bi-app/bi-app-rtl';
   ----^
```