### PR TITLE
add certificate title override

### DIFF
--- a/credentials/apps/api/tests/factories.py
+++ b/credentials/apps/api/tests/factories.py
@@ -31,7 +31,6 @@ class CertificateTemplateFactory(factory.django.DjangoModelFactory):
 class SiteCertificateTemplateBaseFactory(factory.django.DjangoModelFactory):
     site = factory.SubFactory(SiteFactory)
     template = factory.SubFactory(CertificateTemplateFactory)
-    title = 'dummy title'
 
 
 class ProgramCertificateFactory(SiteCertificateTemplateBaseFactory):

--- a/credentials/apps/core/context_processors.py
+++ b/credentials/apps/core/context_processors.py
@@ -5,6 +5,7 @@ from django.conf import settings
 def core(request):
     """ Site-wide context processor. """
     return {
+        'site': request.site,
         'platform_name': settings.PLATFORM_NAME,
         'language_code': request.LANGUAGE_CODE,
     }

--- a/credentials/apps/core/tests/test_context_processors.py
+++ b/credentials/apps/core/tests/test_context_processors.py
@@ -2,6 +2,7 @@
 
 from django.test import override_settings, RequestFactory, TestCase
 
+from credentials.apps.api.tests import factories
 from credentials.apps.core.context_processors import core
 
 
@@ -14,8 +15,13 @@ class CoreContextProcessorTests(TestCase):
 
     @override_settings(PLATFORM_NAME=PLATFORM_NAME)
     def test_core(self):
+        site = factories.SiteFactory()
         request = RequestFactory().get('/')
         request.LANGUAGE_CODE = LANGUAGE_CODE
-        self.assertDictEqual(
-            core(request), {'platform_name': PLATFORM_NAME, 'language_code': LANGUAGE_CODE}
-        )
+        request.site = site
+        expected_output = {
+            'site': site,
+            'platform_name': PLATFORM_NAME,
+            'language_code': LANGUAGE_CODE,
+        }
+        self.assertDictEqual(core(request), expected_output)

--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -52,6 +52,7 @@ class RenderCredential(TemplateView):
         programs_data = self._get_program_data(user_credential.credential.program_id)
         return {
             'credential_type': _(u'XSeries Certificate'),
+            'credential_title': user_credential.credential.title,
             'user_data': get_user(user_credential.username),
             'programs_data': programs_data,
             'organization_data': get_organization(programs_data['organization_key']),

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -57,6 +57,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
     'waffle.middleware.WaffleMiddleware',

--- a/credentials/templates/credentials/base.html
+++ b/credentials/templates/credentials/base.html
@@ -3,7 +3,9 @@
 {% load compress %}
 {% load i18n %}
 {% load staticfiles %}
-{% block title %} {{ certificate_context.credential_type }} | {{ platform_name }}{% endblock title %}
+{% block title %}
+    {{ certificate_context.credential_type }} | {% firstof site.name platform_name %}
+{% endblock title %}
 
 {% block stylesheets %}
     <link rel="stylesheet" href="{% static 'sass/main-ltr.scss' %}" type="text/x-scss">

--- a/credentials/templates/credentials/program_certificate.html
+++ b/credentials/templates/credentials/program_certificate.html
@@ -8,10 +8,10 @@
         <div class="wrapper-header">
             <header class="header-app" role="banner">
                 <h1 class="header-app-title">
-                    <a class="logo" href="http://edx.org">
-                        <img class="logo-img" src="{% static 'images/logo-edX.png' %}" alt="{{ platform_name }} {% trans 'Home' %}" />
+                    <a class="logo" href="{{ site.siteconfiguration.lms_url_root }}">
+                        <img class="logo-img" src="{% static 'images/logo-edX.png' %}" alt="{% firstof site.name platform_name %}" />
                     </a>
-                    <span class="sr-only">{{ certificate_context.organization_data.name }}</span>
+                    <span class="sr-only">{% firstof site.name platform_name %}</span>
                 </h1>
             </header>
         </div>
@@ -88,7 +88,9 @@
                                     <span class="accomplishment-summary copy">successfully completed all courses in the XSeries Program</span>
                                 {% endblocktrans %}
                                 <span class="accomplishment-program">
-                                    <span class="accomplishment-program-name">{{ certificate_context.programs_data.name }}</span>
+                                    <span class="accomplishment-program-name">
+                                        {% firstof certificate_context.credential_title certificate_context.programs_data.name %}
+                                    </span>
                                 </span>
 
                                 <span class="accomplishment-statement-detail copy">


### PR DESCRIPTION
ECOM-3557
@awais786 @ahsan-ul-haq @tasawernawaz 
* Show `title` from the program certificate configurations if set, instead of the program name while rendering the certificate
* User site configuration for linking to its lms url
* Add/Update test for above changes

_Old PR: https://github.com/edx/credentials/pull/49_