### PR TITLE
static files s3 settings

### DIFF
--- a/credentials/settings/production.py
+++ b/credentials/settings/production.py
@@ -20,6 +20,9 @@ with open(CONFIG_FILE) as f:
     config_from_yaml = yaml.load(f)
     vars().update(config_from_yaml)
 
+    # Load the files storage backend settings for django storages
+    vars().update(FILE_STORAGE_BACKEND)
+
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),
     ENGINE=environ.get('DB_MIGRATION_ENGINE', DATABASES['default']['ENGINE']),
@@ -31,9 +34,6 @@ DB_OVERRIDES = dict(
 
 for override, value in DB_OVERRIDES.iteritems():
     DATABASES['default'][override] = value
-
-if AWS_STORAGE_BUCKET_NAME and AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': SOCIAL_AUTH_EDX_OIDC_SECRET,

--- a/credentials/static/sass/_config.scss
+++ b/credentials/static/sass/_config.scss
@@ -6,10 +6,10 @@
 // ------------------------------
 // #VARIABLES
 // ------------------------------
- $font-path: '../bower_components/edx-pattern-library/pattern-library/fonts';
+$font-path: '../bower_components/edx-pattern-library/pattern-library/fonts';
 
-$accomplishment-verified-path: '/static/images';
+$accomplishment-verified-path: '../images';
 
-$accomplishment-professional-path: '/static/images';
+$accomplishment-professional-path: '../images';
 
-$accomplishment-xseries-path: '/static/images';
+$accomplishment-xseries-path: '../images';


### PR DESCRIPTION
ECOM-3605
@awais786 @ahsan-ul-haq @tasawernawaz 
* Remove settings for S3 as these settings will come from configuration https://github.com/edx/configuration/pull/2758/
* Fix the images path in file `_config.scss` to work with S3

Sample S3 config settings:
```yml
AWS_STORAGE_BUCKET_NAME: mybucket
AWS_CUSTOM_DOMAIN: mybucket.s3.amazonaws.com
AWS_ACCESS_KEY_ID: XXXAWS_ACCESS_KEYXXX
AWS_SECRET_ACCESS_KEY: XXXAWS_SECRETY_KEYXXX
AWS_QUERYSTRING_AUTH: False
AWS_QUERYSTRING_EXPIRE: False
AWS_DEFAULT_ACL: ''
AWS_HEADERS:
  Cache-Control: max-age-31536000
  Access-Control-Allow-Origin: PUT YOUR HOSTNAME HERE

COMPRESS_URL: 'https://mybucket.s3.amazonaws.com/'
STATIC_URL: 'https://mybucket.s3.amazonaws.com/'
COMPRESS_ROOT: {{ CREDENTIALS_STATIC_ROOT }}
COMPRESS_STORAGE: 'storages.backends.s3boto.S3BotoStorage'
STATICFILES_STORAGE: 'storages.backends.s3boto.S3BotoStorage'
DEFAULT_FILE_STORAGE: 'storages.backends.s3boto.S3BotoStorage'
```
These settings will come from configuration: https://github.com/edx/configuration/pull/2758/