### PR TITLE
Remove unnecessary padding above print cert icon

### DIFF
--- a/credentials/static/sass/_layouts.scss
+++ b/credentials/static/sass/_layouts.scss
@@ -76,7 +76,6 @@
   }
 
   .message-actions {
-    margin-top: spacing-vertical(small);
     text-align: center;
 
     @include susy-breakpoint($bp-screen-md, $susy) {


### PR DESCRIPTION
@marcotuts @ahsan-ul-haq 

This change takes us from here:

![](https://i.imgur.com/XS7kwnO.png)

To here:

![](https://i.imgur.com/fCSKC0m.png)