### PR TITLE
add S3BotoStorage for static and media files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ source=credentials
 omit =
     credentials/settings*
     credentials/conf*
+    credentials/apps/core/s3utils.py
     *wsgi.py
     *migrations*
     *admin.py

--- a/credentials/apps/core/s3utils.py
+++ b/credentials/apps/core/s3utils.py
@@ -1,0 +1,18 @@
+"""
+Custom S3 storage backends to store files in sub folders.
+"""
+from functools import partial
+
+from django.conf import settings
+from storages.backends.s3boto import S3BotoStorage
+
+
+MediaS3BotoStorage = partial(
+    S3BotoStorage,
+    location=settings.MEDIA_ROOT.strip('/')
+)
+
+StaticS3BotoStorage = partial(
+    S3BotoStorage,
+    location=settings.STATIC_ROOT.strip('/')
+)


### PR DESCRIPTION
@awais786 @ahsan-ul-haq @tasawernawaz @waheedahmed 

Update S3BotoStorage to use 'media' folder for media files and 'staticfiles' for static files.

Related configuration changes: https://github.com/edx/configuration/pull/2781

http://stackoverflow.com/questions/10390244/how-to-set-up-a-django-project-with-django-storages-and-amazon-s3-but-with-diff/10825691#10825691
http://martinbrochhaus.com/s3.html