### PR TITLE
add optional prod requirement to make prod-requirements command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # This file is here because many Platforms as a Service look for
 #	requirements.txt in the root directory of a project.
 -r requirements/production.txt
+-r requirements/optional.txt 


### PR DESCRIPTION
@awais786 @tasawernawaz @waheedahmed 
Fix the issue where the command `make prod-requirements` was not installing optional requirements.

@rlucioni @clintonb @jimabramson @maxrothman Please let me know your thoughts on this approach.
I believe this way we won't have to merge the changes for [removing make target for prod requirements](https://github.com/edx/credentials/pull/69) and [updating the credentials configuration to install application requirements](https://github.com/edx/configuration/pull/2812/).
