### PR TITLE
Adding check only active programs can generate credentials.

### DIFF
--- a/credentials/apps/api/serializers.py
+++ b/credentials/apps/api/serializers.py
@@ -25,16 +25,18 @@ class CredentialField(serializers.Field):
         try:
             if 'program_id' in data and data.get('program_id'):
                 credential_id = data['program_id']
-                return ProgramCertificate.objects.get(program_id=data['program_id'])
+                return ProgramCertificate.objects.get(program_id=data['program_id'], is_active=True)
             elif 'course_id' in data and data.get('course_id') and data.get('certificate_type'):
                 credential_id = data['course_id']
                 return CourseCertificate.objects.get(
                     course_id=data['course_id'],
-                    certificate_type=data['certificate_type'])
+                    certificate_type=data['certificate_type'],
+                    is_active=True
+                )
             else:
                 raise ValidationError("Credential ID is missing.")
         except ObjectDoesNotExist as ex:
-            logger.exception("Credential ID [%s] for [%s]", credential_id, ex.message)
+            logger.exception("Credential ID [%s] for %s", credential_id, ex.message)
             raise ValidationError(ex.message)
 
     def to_representation(self, value):

--- a/credentials/apps/api/tests/factories.py
+++ b/credentials/apps/api/tests/factories.py
@@ -38,6 +38,7 @@ class ProgramCertificateFactory(SiteCertificateTemplateBaseFactory):
         model = models.ProgramCertificate
 
     program_id = factory.Sequence(int)
+    is_active = True
 
 
 class CourseCertificateFactory(SiteCertificateTemplateBaseFactory):
@@ -46,6 +47,7 @@ class CourseCertificateFactory(SiteCertificateTemplateBaseFactory):
 
     course_id = factory.Sequence(lambda o: 'course-%d' % o)
     certificate_type = constants.CertificateType.HONOR
+    is_active = True
 
 
 class UserCredentialFactory(factory.django.DjangoModelFactory):

--- a/credentials/apps/api/tests/test_serializers.py
+++ b/credentials/apps/api/tests/test_serializers.py
@@ -144,6 +144,14 @@ class CredentialFieldTests(TestCase):
         with self.assertRaisesRegexp(ValidationError, "ProgramCertificate matching query does not exist."):
             self.field_instance.to_internal_value({"program_id": 404})
 
+    def test_to_internal_value_with_in_active_program_credential(self,):
+        """Verify that it will return error message if program is not active in db."""
+        self.program_cert.is_active = False
+        self.program_cert.save()
+
+        with self.assertRaisesRegexp(ValidationError, "ProgramCertificate matching query does not exist."):
+            self.field_instance.to_internal_value({"program_id": 404})
+
     def test_to_internal_value_with_invalid_course_credential(self):
         """Verify that it will return error message if course-id does not exist in db."""
 


### PR DESCRIPTION
Adding checks so that only active ProgramCertificate configurations can generate credentials. I have added check for CourseCertificates too.
https://openedx.atlassian.net/browse/ECOM-3858