### PR TITLE
reword pip requirement for boto fork

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Workaround for https://github.com/boto/boto/issues/1477
-git+https://github.com/leonsim/boto.git@49b7a6e6a86f4192e7cc429cf23c427e34f36921#egg=boto==49b7a6e6a86f4192e7cc429cf23c427e34f36921
+git+https://github.com/leonsim/boto.git@49b7a6e6a86f4192e7cc429cf23c427e34f36921#egg=boto
 
 django==1.8.10
 django-compressor==1.6


### PR DESCRIPTION
@maxrothman @zubair-arbi 

the prior phrasing seemed to cause pip to fall back to installing the latest release version, instead of the commit.