### PR TITLE
Use django template tag for removing the querystrings from media images url

### DIFF
--- a/credentials/apps/credentials/templatetags/util_tags.py
+++ b/credentials/apps/credentials/templatetags/util_tags.py
@@ -10,7 +10,7 @@ register = template.Library()
 
 
 @register.filter(name='strip_querystrings')
-def strip_querystrings(value):
+def strip_querystrings(url):
     """ Helper method to remove querystrings from the provided url.
 
     If url has querystring params than split it and return the first part.
@@ -20,5 +20,5 @@ def strip_querystrings(value):
     """
 
     # value is coming with url-encoding and "?" is appearing as %3F.
-    value = urllib.unquote(value)
-    return value.split('?')[0] if '?' in value else value
+    url = urllib.unquote(url)
+    return url.split('?')[0] if '?' in url else url

--- a/credentials/apps/credentials/templatetags/util_tags.py
+++ b/credentials/apps/credentials/templatetags/util_tags.py
@@ -1,0 +1,24 @@
+"""
+Template tags for credentials.
+"""
+import urllib
+
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter(name='strip_querystrings')
+def strip_querystrings(value):
+    """ Helper method to remove querystrings from the provided url.
+
+    If url has querystring params than split it and return the first part.
+
+    Arguments:
+        url (str): URL for cleanup
+    """
+
+    # value is coming with url-encoding and "?" is appearing as %3F.
+    value = urllib.unquote(value)
+    return value.split('?')[0] if '?' in value else value

--- a/credentials/templates/credentials/program_certificate.html
+++ b/credentials/templates/credentials/program_certificate.html
@@ -1,5 +1,8 @@
 {% load i18n %}
 {% load staticfiles %}
+{% load util_tags %}
+{% load waffle_tags %}
+
 {% block content %}
 <div class="layout-accomplishment view-valid-accomplishment ltr certificate certificate-xseries" data-view="valid-accomplishment">
 
@@ -109,7 +112,11 @@
                                     {% for signatory in user_credential.credential.signatories.all %}
                                     <div class="signatory">
                                         {% if signatory.image %}
-                                            <img class="signatory-signature" src="{{signatory.image.url}}" alt="{{signatory.name}}">
+                                            {% switch "strip_image_querystrings" %}
+                                                <img class="signatory-signature" src="{{ signatory.image.url|strip_querystrings }}" alt="{{ signatory.name }}">
+                                            {% else %}
+                                                <img class="signatory-signature" src="{{ signatory.image.url }}" alt="{{ signatory.name }}">
+                                            {% endswitch %}
                                         {% endif %}
                                         <h4 class="signatory-name">{{ signatory.name }}</h4>
 


### PR DESCRIPTION
@awais786 @tasawernawaz 
Custom template tag `strip_querystrings` is added to strip the querystrings from the media images url.
To enable this functionality add the waffle switch **`strip_image_querystrings`** and mark it as active from django admin panel.

_**Note:** For some unknown reasons `boto` is adding querystring `x-amz-security-token` with the s3 images on stage. At the moment team is trying different solutions to fix that. But for the last resort this PR is created._

Related PR: https://github.com/edx/credentials/pull/81