### PR TITLE
re-revert boto fix by jim

### DIFF
--- a/credentials/apps/core/s3utils.py
+++ b/credentials/apps/core/s3utils.py
@@ -9,10 +9,10 @@ from storages.backends.s3boto import S3BotoStorage
 
 MediaS3BotoStorage = partial(
     S3BotoStorage,
-    location=settings.MEDIA_ROOT.strip('/'),
+    location=settings.MEDIA_ROOT.strip('/')
 )
 
 StaticS3BotoStorage = partial(
     S3BotoStorage,
-    location=settings.STATIC_ROOT.strip('/'),
+    location=settings.STATIC_ROOT.strip('/')
 )

--- a/credentials/apps/core/s3utils.py
+++ b/credentials/apps/core/s3utils.py
@@ -3,16 +3,32 @@ Custom S3 storage backends to store files in sub folders.
 """
 from functools import partial
 
+from boto.s3.connection import S3Connection
 from django.conf import settings
 from storages.backends.s3boto import S3BotoStorage
 
 
+class S3NoSecurityTokenConnection(S3Connection):
+    """
+    Workaround for https://github.com/boto/boto/issues/1477
+
+    This is done to suppress boto's default behavior of generating unwanted
+    query strings in s3 URLs when used in AWS accounts with certain SigV4
+    configurations.
+    """
+    def __init__(self, *a, **kw):
+        super(S3NoSecurityTokenConnection, self).__init__(*a, **kw)
+        self.provider.security_token = ""
+
+
 MediaS3BotoStorage = partial(
     S3BotoStorage,
-    location=settings.MEDIA_ROOT.strip('/')
+    location=settings.MEDIA_ROOT.strip('/'),
+    connection_class=S3NoSecurityTokenConnection
 )
 
 StaticS3BotoStorage = partial(
     S3BotoStorage,
-    location=settings.STATIC_ROOT.strip('/')
+    location=settings.STATIC_ROOT.strip('/'),
+    connection_class=S3NoSecurityTokenConnection
 )

--- a/credentials/apps/core/tests/test_s3utils.py
+++ b/credentials/apps/core/tests/test_s3utils.py
@@ -1,0 +1,29 @@
+"""
+Tests for s3 library customization utilities.
+"""
+
+from django.test import TestCase
+import mock
+
+from credentials.apps.core.s3utils import MediaS3BotoStorage, StaticS3BotoStorage
+
+
+class TestS3NoSecurityTokenConnection(TestCase):
+    """
+    Tests for the custom s3 connection.
+    """
+
+    def test_no_security_token(self):
+        """
+        Ensure the querystring-inhibiting workaround takes effect with our
+        custom S3 storage drivers.
+        """
+        # note that the default value for the security token is None in a non-AWS env;
+        # therefore our manually-set empty string indicates that the override is working
+
+        with mock.patch('boto.auth.get_auth_handler'):  # prevents errors running in TravisCI
+            media_storage = MediaS3BotoStorage()
+            self.assertEqual(media_storage.connection.provider.security_token, "")
+
+            static_storage = StaticS3BotoStorage()
+            self.assertEqual(static_storage.connection.provider.security_token, "")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,3 @@
-# Workaround for https://github.com/boto/boto/issues/1477
-git+https://github.com/leonsim/boto.git@49b7a6e6a86f4192e7cc429cf23c427e34f36921#egg=boto==49b7a6e6a86f4192e7cc429cf23c427e34f36921
-
 django==1.8.10
 django-compressor==1.6
 django-extensions==1.6.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,6 @@
-boto==2.32.1
+# Workaround for https://github.com/boto/boto/issues/1477
+git+https://github.com/leonsim/boto.git@49b7a6e6a86f4192e7cc429cf23c427e34f36921#egg=boto
+
 django==1.8.10
 django-compressor==1.6
 django-extensions==1.6.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
+boto==2.32.1
 django==1.8.10
 django-compressor==1.6
 django-extensions==1.6.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,7 +1,6 @@
 # Packages required in a production environment
 -r base.txt
 
-boto==2.32.1
 gevent==1.0.2
 gunicorn==19.3.0
 MySQL-python==1.2.5

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,6 +1,7 @@
 # Packages required in a production environment
 -r base.txt
 
+boto==2.32.1
 gevent==1.0.2
 gunicorn==19.3.0
 MySQL-python==1.2.5


### PR DESCRIPTION
@awais786 @tasawernawaz @waheedahmed 
I have verified on my sandbox that @jimabramson fix is working fine for more than 1 hour so my understanding is that this fix is working and we will check for how long it works for future reference if it stops working again.

So going forward I say we should merge this PR and for workaround (just in case) we will also merge the @awais786 [PR for disabling aws querystrings for media images](https://github.com/edx/credentials/pull/80) with a waffle switch 'strip_image_querystrings'.

Related PR's:
- https://github.com/edx/credentials/pull/73 (override boto class `S3Connection` for empty `security_token`)
- https://github.com/edx/credentials/pull/76 (Use leonsim's fork for boto for fixing aws querysting issue)
- https://github.com/edx/credentials/pull/79 (reword pip requirement for leonsim's boto fork)
- https://github.com/edx/credentials/pull/80 (django template tag to remove querystrings from media images url)