### PR TITLE
Revert "use leonsim's fork of boto for fixing aws querysting issue"

### DIFF
--- a/credentials/apps/core/s3utils.py
+++ b/credentials/apps/core/s3utils.py
@@ -9,10 +9,10 @@ from storages.backends.s3boto import S3BotoStorage
 
 MediaS3BotoStorage = partial(
     S3BotoStorage,
-    location=settings.MEDIA_ROOT.strip('/'),
+    location=settings.MEDIA_ROOT.strip('/')
 )
 
 StaticS3BotoStorage = partial(
     S3BotoStorage,
-    location=settings.STATIC_ROOT.strip('/'),
+    location=settings.STATIC_ROOT.strip('/')
 )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,3 @@
-# Workaround for https://github.com/boto/boto/issues/1477
-git+https://github.com/leonsim/boto.git@49b7a6e6a86f4192e7cc429cf23c427e34f36921#egg=boto==49b7a6e6a86f4192e7cc429cf23c427e34f36921
-
 django==1.8.10
 django-compressor==1.6
 django-extensions==1.6.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,6 +1,7 @@
 # Packages required in a production environment
 -r base.txt
 
+boto==2.32.1
 gevent==1.0.2
 gunicorn==19.3.0
 MySQL-python==1.2.5


### PR DESCRIPTION
This reverts commit d60176274186825ed9d71ecdf8697681f1932946.

The workaround we needed was in configuration all along, but had the wrong name (fixed in https://github.com/edx/configuration/pull/2840)