### PR TITLE
update version for ux-pattern-library

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "backbone": "~1.2.1",
     "backbone.validation": "backbone-validation#~0.11.5",
-    "edx-pattern-library": "^0.8.5",
+    "edx-pattern-library": "^0.10.4",
     "jquery": "~2.1.4",
     "jquery-cookie": "~1.4.1",
     "requirejs": "~2.1.15",


### PR DESCRIPTION
ECOM-3826
@awais786 @tasawernawaz @waheedahmed 

* bumped the `ux-pattern-library` version from `0.8.5` to `0.10.4`.
* The older version was giving error for missing [edx-icons svg files in the fallback-img directory](https://github.com/edx/ux-pattern-library/tree/master/pattern-library/fonts/edx-icons/fallback-img) when we try to use [django's storage backend 'ManifestStaticFilesStorage'](https://docs.djangoproject.com/en/1.8/ref/contrib/staticfiles/#manifeststaticfilesstorage) for versioning of static files.
```
Post-processing 'build/bower_components/edx-pattern-library/pattern-library/css/edx-pattern-library-ltr.css' failed!

Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/zubairafzal1/Workspace/devstack/credentials_env/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/Users/zubairafzal1/Workspace/devstack/credentials_env/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/zubairafzal1/Workspace/devstack/credentials_env/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/zubairafzal1/Workspace/devstack/credentials_env/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/Users/zubairafzal1/Workspace/devstack/credentials_env/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 168, in handle
    collected = self.collect()
  File "/Users/zubairafzal1/Workspace/devstack/credentials_env/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 120, in collect
    raise processed
ValueError: The file 'build/bower_components/edx-pattern-library/pattern-library/fonts/edx-icons/fallback-img/genderless.svg' could not be found with <django.contrib.staticfiles.storage.ManifestStaticFilesStorage object at 0x105406e50>.
make: *** [static] Error 1

```

FYI: @marcotuts @jimabramson @maxrothman 