### PR TITLE
Only authenticated users can acccess the list end point.

### DIFF
--- a/credentials/apps/api/tests/test_views.py
+++ b/credentials/apps/api/tests/test_views.py
@@ -406,6 +406,13 @@ class UserCredentialViewSetTests(APITestCase):
         actual_attributes = [{"name": attr.name, "value": attr.value} for attr in user_credential[0].attributes.all()]
         self.assertEqual(actual_attributes, expected_attrs)
 
+    def test_users_lists_access_by_authenticated_users(self):
+        """ Verify the list endpoint can be access by authenticated users only."""
+        # logout the user
+        self.client.logout()
+        response = self.client.get(self.list_path, data={'username': self.user_credential.username})
+        self.assertEqual(response.status_code, 401)
+
 
 class CredentialViewSetTests(APITestCase):
     """ Base Class for ProgramCredentialViewSetTests and CourseCredentialViewSetTests. """

--- a/credentials/apps/api/v1/views.py
+++ b/credentials/apps/api/v1/views.py
@@ -5,7 +5,7 @@ import logging
 
 from rest_framework import filters, mixins, viewsets
 from rest_framework.exceptions import ValidationError
-from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
+from rest_framework.permissions import DjangoModelPermissions
 from credentials.apps.api.filters import ProgramFilter, CourseFilter
 
 from credentials.apps.api.serializers import UserCredentialCreationSerializer, UserCredentialSerializer
@@ -22,7 +22,7 @@ class UserCredentialViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.DjangoFilterBackend,)
     filter_fields = ('username', 'status')
     serializer_class = UserCredentialSerializer
-    permission_classes = (DjangoModelPermissionsOrAnonReadOnly,)
+    permission_classes = (DjangoModelPermissions,)
 
     def list(self, request, *args, **kwargs):
         if not self.request.query_params.get('username'):


### PR DESCRIPTION
ECOM-3978
Previously anonymous users can access the end point and get all credentials information. Now only Authenticated users can access the endpoint.

For sharing purpose rendering credential is already open for all users. So sharing will work.
