### PR TITLE
update docker-compose file to use version 2 format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,11 @@ push_translations:
 	tx push -s
 
 start-devstack:
-	docker-compose --x-networking up
+	docker-compose up
 
 open-devstack:
-	docker exec -it credentials /edx/app/credentials/devstack.sh open
+	docker-compose up -d
+	docker exec -it credentials env TERM=$(TERM) /edx/app/credentials/devstack.sh open
 
 pkg-devstack:
 	docker build -t credentials:latest -f docker/build/credentials/Dockerfile git://github.com/edx/configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,37 @@
-db:
-  image: mysql:5.6
-  container_name: db
-  environment:
-    MYSQL_ROOT_PASSWORD: ""
-    MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+version: "2"
 
-memcache:
-  image: memcached:1.4.24
-  container_name: memcache
+services:
+  db:
+    image: mysql:5.6
+    container_name: db
+    environment:
+      MYSQL_ROOT_PASSWORD: ""
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_USER: "credentials001"
+      MYSQL_PASSWORD: "password"
+      MYSQL_DATABASE: "credentials"
+    ports:
+      - "3306:3306"
 
-credentials:
-  # Uncomment this line to use the official credentials base image
-  image: credentials:v1
+  memcache:
+    image: memcached:1.4.24
+    container_name: memcache
 
-  # Uncomment the next two lines to build from a local configuration repo
-  #build: ../configuration
-  #dockerfile: docker/build/credentials/Dockerfile
+  credentials:
+    # Uncomment this line to use the official credentials base image
+    image: edxops/credentials:latest
 
-  container_name: credentials
-  volumes:
-    - .:/edx/app/credentials/credentials
-  command: /edx/app/credentials/devstack.sh start
-  ports:
-    - "8150:8150" # TODO: change this to your port
+    # Uncomment the next two lines to build from a local configuration repo
+    #build: ../configuration
+    #dockerfile: docker/build/credentials/Dockerfile
+
+    container_name: credentials
+    volumes:
+      - .:/edx/app/credentials/credentials
+    command: /edx/app/credentials/devstack.sh start
+    depends_on:
+      - "db"
+      - "memcache"
+    ports:
+      - "8150:8150"
+      - "18150:18150"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,5 +16,7 @@ edx-rest-api-client==1.4.0
 libsass==0.10.0
 Pillow==3.0.0
 python-memcached==1.57
+# Remove once https://github.com/omab/python-social-auth/pull/897 is merged/released.
+python-social-auth==0.2.14
 pytz==2015.7
 git+https://github.com/edx/opaque-keys.git@9f07da1abf699d10bc3252d3081017e8aa37c302#egg=opaque-keys


### PR DESCRIPTION
ECOM-3180
@awais786 @ahsan-ul-haq @tasawernawaz @waheedahmed 

*  Update `docker-compose.yml` to use [version 2 format](https://docs.docker.com/compose/compose-file/#version-2)
* Add base credentials for mysql container