### PR TITLE
Added ability to override issuing organization for credentials.

### DIFF
--- a/credentials/apps/credentials/migrations/0003_programcertificate_use_org_name.py
+++ b/credentials/apps/credentials/migrations/0003_programcertificate_use_org_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('credentials', '0002_signatory_organization_name_override'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='programcertificate',
+            name='use_org_name',
+            field=models.BooleanField(default=False, help_text="Display the associated organization's name (e.g. ACME University) instead of its short name (e.g. ACMEx)", verbose_name='Use organization name'),
+        ),
+    ]

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -233,6 +233,12 @@ class ProgramCertificate(AbstractCertificate):
         object_id_field='credential_id',
         related_query_name='program_credentials'
     )
+    use_org_name = models.BooleanField(
+        default=False,
+        help_text=_("Display the associated organization's name (e.g. ACME University) "
+                    "instead of its short name (e.g. ACMEx)"),
+        verbose_name=_('Use organization name')
+    )
 
     class Meta(object):
         verbose_name = "Program certificate configuration"

--- a/credentials/apps/credentials/tests/test_views.py
+++ b/credentials/apps/credentials/tests/test_views.py
@@ -189,3 +189,22 @@ class RenderCredentialPageTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.signatory_1.organization_name_override)
         self.assertNotContains(response, self.signatory_2.organization_name_override)
+
+    def test_issuing_organization_name_override(self):
+        """ Verify that the view response contains organization 'name' instead of 'short_name'
+        if 'use_org_name' is True."""
+        response = self._render_user_credential()
+
+        self.assertEqual(
+            response.context['certificate_context']['organization_name'],
+            OrganizationsDataMixin.ORGANIZATIONS_API_RESPONSE['short_name']
+        )
+
+        self.program_certificate.use_org_name = True
+        self.program_certificate.save()
+        response = self._render_user_credential()
+
+        self.assertEqual(
+            response.context['certificate_context']['organization_name'],
+            OrganizationsDataMixin.ORGANIZATIONS_API_RESPONSE['name']
+        )

--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -50,12 +50,18 @@ class RenderCredential(TemplateView):
              lms service and template path.
         """
         programs_data = self._get_program_data(user_credential.credential.program_id)
+        organization_data = get_organization(programs_data['organization_key'])
+        organization_name = organization_data['short_name']
+        if user_credential.credential.use_org_name:
+            organization_name = organization_data['name']
+
         return {
             'credential_type': _(u'XSeries Certificate'),
             'credential_title': user_credential.credential.title,
             'user_data': get_user(user_credential.username),
             'programs_data': programs_data,
-            'organization_data': get_organization(programs_data['organization_key']),
+            'organization_data': organization_data,
+            'organization_name': organization_name,
             'credential_template': 'credentials/program_certificate.html',
         }
 

--- a/credentials/templates/credentials/program_certificate.html
+++ b/credentials/templates/credentials/program_certificate.html
@@ -96,7 +96,7 @@
 
                                 <span class="accomplishment-statement-detail copy">
                                     {# Translators: course_count is an integer value, and name is the display name for the provided organization e.g Test Organization. #}
-                                    {% blocktrans with course_count=certificate_context.programs_data.course_count name=certificate_context.organization_data.short_name platform_name=platform_name %}
+                                    {% blocktrans with course_count=certificate_context.programs_data.course_count name=certificate_context.organization_name platform_name=platform_name %}
                                         a series of {{ course_count }} courses offered by {{ name }} through {{ platform_name }}.
                                     {% endblocktrans %}
                                 </span>


### PR DESCRIPTION
[ECOM-4198] (https://openedx.atlassian.net/browse/ECOM-4198)

In order to support the existing use of wrapper-organizations such as VJx, added the ability to override the issuing organization on credentials (specifically XSeries, as courses already have this.)