### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ djangorestframework-jwt==1.7.2
 django-rest-swagger==0.3.4
 django-storages==1.1.8
 edx-auth-backends==0.5.0
-edx-django-release-util==0.1.0
+edx-django-release-util==0.1.1
 edx-drf-extensions==0.5.1
 edx-opaque-keys==0.3.1
 edx-rest-api-client==1.4.0


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.1.1.

@edx/ecommerce  Please review and tag appropriate parties.