### PR TITLE
Upgrade Django to 1.8.15

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-django==1.8.14
+django==1.8.15
 django-compressor==1.6
 django-extensions==1.6.1
 django-libsass==0.6


### PR DESCRIPTION
Django 1.8.15 fixes a security issue in 1.8.14. Release notes are at https://docs.djangoproject.com/en/1.10/releases/1.8.15.

@edx/ecommerce FYI.