### PR TITLE
Update Transifex config to avoid searching for nonexistent PO file

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -6,9 +6,3 @@ file_filter = credentials/conf/locale/<lang>/LC_MESSAGES/django.po
 source_file = credentials/conf/locale/en/LC_MESSAGES/django.po
 source_lang = en
 type = PO
-
-[edx-platform.credentials-js]
-file_filter = credentials/conf/locale/<lang>/LC_MESSAGES/djangojs.po
-source_file = credentials/conf/locale/en/LC_MESSAGES/djangojs.po
-source_lang = en
-type = PO


### PR DESCRIPTION
Credentials has no djangojs.po.

@clintonb please review. @edx/ecommerce FYI.