### PR TITLE
Avoid attempting to validate non-existent translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ html_coverage:
 
 extract_translations:
 	python manage.py makemessages -l en -v1 -d django
-	python manage.py makemessages -l en -v1 -d djangojs
 
 dummy_translations:
 	cd credentials && i18n_tool dummy


### PR DESCRIPTION
This repo has no djangojs source.