### PR TITLE
Upgrade edx-auth-backends to 0.5.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ djangorestframework==3.2.3
 djangorestframework-jwt==1.7.2
 django-rest-swagger==0.3.4
 django-storages==1.1.8
-edx-auth-backends==0.5.0
+edx-auth-backends==0.5.3
 edx-django-release-util==0.1.2
 edx-drf-extensions==0.5.1
 edx-opaque-keys==0.3.1


### PR DESCRIPTION
This version of the package limits the installed version of PSA to <0.3.0. 0.3.0 introduced a major breaking change, effectively gutting PSA and moving its Django components to a new social-auth-app-django package.

@edx/ecommerce @jibsheet FYI. This is follow-up to https://github.com/edx/auth-backends/pull/27 and should fix CI builds.