### PR TITLE
Tweak program type logo css

### DIFF
--- a/credentials/static/sass/_layouts-rendering.scss
+++ b/credentials/static/sass/_layouts-rendering.scss
@@ -50,14 +50,24 @@
     margin-top: spacing-vertical(x-small);
     margin-bottom: spacing-vertical(base);
 
+    svg {
+      width: 250px;
+    }
+
     @include susy-breakpoint($bp-screen-md, $susy) {
       display: inline-block;
       vertical-align: middle;
       width: span(6 of 12);
+      svg {
+        width: 275px;
+      }
     }
 
     @include susy-breakpoint($bp-screen-lg, $susy) {
       width: span(6 of 12);
+      svg {
+        width: 300px;
+      }
     }
 
     .micromasters-logo {
@@ -158,7 +168,7 @@
   .accomplishment-stamp-platform {
     margin-bottom: spacing-vertical(small);
 
-    .logo-img {
+    .logo-img svg {
       width: 125px;
       margin-top: 2px;
     }

--- a/credentials/static/sass/_print-rendering.scss
+++ b/credentials/static/sass/_print-rendering.scss
@@ -89,6 +89,9 @@
             width: span(1 of 12);
             margin-bottom: 0;
             padding-top: 0;
+            .logo-img svg {
+                width: 100px;
+            }
         }
 
         .accomplishment-stamp-date {


### PR DESCRIPTION
The program type logos and edx logo were too big, so this makes them smaller. 
@edx/ecommerce 