### PR TITLE
Removed all references to program ID in API v2

### DIFF
--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -1,0 +1,134 @@
+"""
+Serializers for data manipulated by the credentials service APIs.
+"""
+import logging
+
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+from rest_framework.reverse import reverse
+
+from credentials.apps.api.accreditors import Accreditor
+from credentials.apps.credentials.models import (
+    CourseCertificate, ProgramCertificate, UserCredential, UserCredentialAttribute
+)
+from credentials.apps.credentials.utils import validate_duplicate_attributes
+
+logger = logging.getLogger(__name__)
+
+
+class CredentialField(serializers.Field):
+    """ Field identifying the credential type and identifiers."""
+
+    def to_internal_value(self, data):
+        credential_id = None
+        try:
+            if 'program_uuid' in data and data.get('program_uuid'):
+                credential_id = data['program_uuid']
+                return ProgramCertificate.objects.get(program_uuid=credential_id, is_active=True)
+            elif 'course_id' in data and data.get('course_id') and data.get('certificate_type'):
+                credential_id = data['course_id']
+                return CourseCertificate.objects.get(
+                    course_id=credential_id,
+                    certificate_type=data['certificate_type'],
+                    is_active=True
+                )
+            else:
+                raise ValidationError('Credential ID is missing.')
+        except ObjectDoesNotExist as ex:
+            logger.exception('Credential ID [%s] for %s', credential_id, ex.message)
+            raise ValidationError(ex.message)
+
+    def to_representation(self, value):
+        """ Serialize objects to a according to model content-type. """
+        credential = {
+            'credential_id': value.id
+        }
+        if isinstance(value, ProgramCertificate):
+            credential.update({
+                'program_uuid': value.program_uuid,
+            })
+        elif isinstance(value, CourseCertificate):
+            credential.update({
+                'course_id': value.course_id,
+                'certificate_type': value.certificate_type
+            })
+
+        return credential
+
+
+class UserCertificateURLField(serializers.ReadOnlyField):  # pylint: disable=abstract-method
+    """ Field for UserCredential URL pointing html view """
+
+    def to_representation(self, value):
+        """ Build the UserCredential URL for html view. Get the current domain from request. """
+        return reverse(
+            'credentials:render',
+            kwargs={
+                'uuid': value.hex,
+            },
+            request=self.context['request']
+        )
+
+
+class UserCredentialAttributeSerializer(serializers.ModelSerializer):
+    """ Serializer for CredentialAttribute objects """
+
+    class Meta(object):
+        model = UserCredentialAttribute
+        fields = ('name', 'value')
+
+
+class UserCredentialSerializer(serializers.ModelSerializer):
+    """ Serializer for UserCredential objects. """
+
+    credential = CredentialField(read_only=True)
+    attributes = UserCredentialAttributeSerializer(many=True, read_only=True)
+    certificate_url = UserCertificateURLField(source='uuid')
+
+    class Meta(object):
+        model = UserCredential
+        fields = (
+            'id', 'username', 'credential', 'status', 'download_url', 'uuid', 'attributes', 'created', 'modified',
+            'certificate_url',
+        )
+        read_only_fields = (
+            'username', 'download_url', 'uuid', 'created', 'modified',
+        )
+
+
+class UserCredentialCreationSerializer(serializers.ModelSerializer):
+    """ Serializer used to create UserCredential objects. """
+    credential = CredentialField()
+    attributes = UserCredentialAttributeSerializer(many=True)
+    certificate_url = UserCertificateURLField(source='uuid')
+
+    def validate_attributes(self, data):
+        """ Check that the name attributes cannot be duplicated."""
+        if not validate_duplicate_attributes(data):
+            raise ValidationError('Attributes cannot be duplicated.')
+        return data
+
+    def issue_credential(self, validated_data):
+        """
+        Issue a new credential.
+
+        Args:
+            validated_data (dict): Input data specifying the credential type, recipient, and attributes.
+
+        Returns:
+            AbstractCredential
+        """
+        accreditor = Accreditor()
+        credential = validated_data['credential']
+        username = validated_data['username']
+        attributes = validated_data.pop('attributes', None)
+
+        return accreditor.issue_credential(credential, username, attributes)
+
+    def create(self, validated_data):
+        return self.issue_credential(validated_data)
+
+    class Meta(object):
+        model = UserCredential
+        exclude = ('credential_content_type', 'credential_id')

--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -89,7 +89,7 @@ class UserCredentialSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = UserCredential
         fields = (
-            'id', 'username', 'credential', 'status', 'download_url', 'uuid', 'attributes', 'created', 'modified',
+            'username', 'credential', 'status', 'download_url', 'uuid', 'attributes', 'created', 'modified',
             'certificate_url',
         )
         read_only_fields = (

--- a/credentials/apps/api/v2/tests/mixins.py
+++ b/credentials/apps/api/v2/tests/mixins.py
@@ -1,0 +1,121 @@
+"""
+Mixins for Credentials API tests.
+"""
+from time import time
+
+import jwt
+from django.conf import settings
+from django.contrib.auth.models import Group
+from rest_framework.test import APIRequestFactory
+
+from credentials.apps.api.v2.serializers import UserCredentialSerializer
+from credentials.apps.core.constants import Role
+from credentials.apps.core.tests.factories import UserFactory
+
+JWT_AUTH = 'JWT_AUTH'
+
+
+class JwtMixin(object):
+    """ Mixin with JWT-related helper functions. """
+
+    JWT_SECRET_KEY = getattr(settings, JWT_AUTH)['JWT_SECRET_KEY']
+    JWT_ISSUER = getattr(settings, JWT_AUTH)['JWT_ISSUER']
+    JWT_AUDIENCE = getattr(settings, JWT_AUTH)['JWT_AUDIENCE']
+
+    def generate_token(self, payload, secret=None):
+        """Generate a JWT token with the provided payload."""
+        secret = secret or self.JWT_SECRET_KEY
+        token = jwt.encode(payload, secret)
+        return token
+
+    def generate_id_token(self, user, admin=False, ttl=1, **overrides):
+        """Generate a JWT id_token that looks like the ones currently
+        returned by the edx oidc provider."""
+
+        payload = self.default_payload(user=user, admin=admin, ttl=ttl)
+        payload.update(overrides)
+        return self.generate_token(payload)
+
+    def default_payload(self, user, admin=False, ttl=1):
+        """Generate a bare payload, in case tests need to manipulate
+        it directly before encoding."""
+        now = int(time())
+
+        return {
+            "iss": self.JWT_ISSUER,
+            "sub": user.pk,
+            "aud": self.JWT_AUDIENCE,
+            "nonce": "dummy-nonce",
+            "exp": now + ttl,
+            "iat": now,
+            "preferred_username": user.username,
+            "administrator": admin,
+            "email": user.email,
+            "locale": "en",
+            "name": user.full_name,
+            "given_name": "",
+            "family_name": "",
+        }
+
+
+class CredentialViewSetTestsMixin(object):
+    """ Base Class for ProgramCredentialViewSetTests and CourseCredentialViewSetTests. """
+
+    list_path = None
+    user_credential = None
+
+    #  pylint: disable=no-member
+    def setUp(self):
+        super(CredentialViewSetTestsMixin, self).setUp()
+
+        self.user = UserFactory()
+        self.user.groups.add(Group.objects.get(name=Role.ADMINS))
+        self.client.force_authenticate(self.user)
+        self.request = APIRequestFactory().get('/')
+
+    def assert_permission_required(self, data):
+        """
+        Ensure access to these APIs is restricted to those with explicit model
+        permissions.
+        """
+        self.client.force_authenticate(user=UserFactory())
+        response = self.client.get(self.list_path, data)
+        self.assertEqual(response.status_code, 403)
+
+    def assert_list_without_id_filter(self, path, expected, data=None):
+        """Helper method used for making request and assertions. """
+        response = self.client.get(path, data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, expected)
+
+    def assert_list_with_id_filter(self, data=None, should_exist=True):
+        """Helper method used for making request and assertions. """
+        expected = self._generate_results(should_exist)
+        response = self.client.get(self.list_path, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, expected)
+
+    def assert_list_with_status_filter(self, data, should_exist=True):
+        """Helper method for making request and assertions. """
+        expected = self._generate_results(should_exist)
+        response = self.client.get(self.list_path, data, expected)
+        self.assertEqual(response.data, expected)
+
+    def _generate_results(self, exists=True):
+        data = {
+            'count': 0,
+            'next': None,
+            'previous': None,
+            'results': []
+        }
+        if exists:
+            data = {
+                'count': 1,
+                'next': None,
+                'previous': None,
+                'results': [UserCredentialSerializer(self.user_credential, context={'request': self.request}).data]
+            }
+
+        return data

--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -1,0 +1,206 @@
+""" Tests for Credit API serializers. """
+# pylint: disable=no-member
+from __future__ import unicode_literals
+
+from uuid import uuid4
+
+import ddt
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+from rest_framework.settings import api_settings
+from rest_framework.test import APIRequestFactory
+
+from credentials.apps.api.v2 import serializers
+from credentials.apps.credentials.tests.factories import (
+    CourseCertificateFactory, ProgramCertificateFactory, UserCredentialFactory, UserCredentialAttributeFactory
+)
+
+
+class UserCredentialSerializerTests(TestCase):
+    """ UserCredentialSerializer tests. """
+
+    def setUp(self):
+        super(UserCredentialSerializerTests, self).setUp()
+
+        self.program_cert = ProgramCertificateFactory()
+        self.program_credential = UserCredentialFactory(credential=self.program_cert)
+        self.program_cert_attr = UserCredentialAttributeFactory(user_credential=self.program_credential)
+
+        self.course_cert = CourseCertificateFactory.create()
+        self.course_credential = UserCredentialFactory.create(credential=self.course_cert)
+        self.course_cert_attr = UserCredentialAttributeFactory(user_credential=self.course_credential)
+        self.request = APIRequestFactory().get('/')
+
+    def test_serialization_with_program_credential(self):
+        """ Verify the serializer correctly serializes program credentials."""
+
+        actual = serializers.UserCredentialSerializer(self.program_credential, context={
+            'request': self.request
+        }).data
+
+        expected_url = 'http://testserver{}'.format(reverse('credentials:render', kwargs={
+            'uuid': self.program_credential.uuid.hex,
+        }))
+
+        expected = {
+            'username': self.program_credential.username,
+            'uuid': str(self.program_credential.uuid),
+            'credential': {
+                'program_uuid': self.program_cert.program_uuid,
+                'credential_id': self.program_cert.id,
+            },
+            'download_url': self.program_credential.download_url,
+            'status': self.program_credential.status,
+            'attributes': [
+                {
+                    'name': self.program_cert_attr.name,
+                    'value': self.program_cert_attr.value
+                }
+            ],
+            'id': self.program_credential.id,
+            'created': self.program_credential.created.strftime(api_settings.DATETIME_FORMAT),
+            'modified': self.program_credential.modified.strftime(api_settings.DATETIME_FORMAT),
+            'certificate_url': expected_url
+        }
+        self.assertEqual(actual, expected)
+
+    def test_serialization_with_course_credential(self):
+        """ Verify the serializer correctly serializes course credentials."""
+
+        actual = serializers.UserCredentialSerializer(self.course_credential, context={
+            'request': self.request
+        }).data
+
+        expected_url = 'http://testserver{}'.format(reverse('credentials:render', kwargs={
+            'uuid': self.course_credential.uuid.hex,
+        }))
+
+        expected = {
+            'username': self.course_credential.username,
+            'uuid': str(self.course_credential.uuid),
+            'credential': {
+                'course_id': self.course_cert.course_id,
+                'certificate_type': self.course_cert.certificate_type,
+                'credential_id': self.course_cert.id
+            },
+            'download_url': self.course_credential.download_url,
+            'status': self.course_credential.status,
+            'attributes': [
+                {
+                    'name': self.course_cert_attr.name,
+                    'value': self.course_cert_attr.value
+                }
+            ],
+            'id': self.course_credential.id,
+            'created': self.course_credential.created.strftime(api_settings.DATETIME_FORMAT),
+            'modified': self.course_credential.modified.strftime(api_settings.DATETIME_FORMAT),
+            'certificate_url': expected_url,
+        }
+        self.assertEqual(actual, expected)
+
+
+class UserCredentialAttributeSerializerTests(TestCase):
+    """ CredentialAttributeSerializer tests. """
+
+    def setUp(self):
+        super(UserCredentialAttributeSerializerTests, self).setUp()
+        self.program_cert = ProgramCertificateFactory()
+        self.program_credential = UserCredentialFactory(credential=self.program_cert)
+        self.program_cert_attr = UserCredentialAttributeFactory(user_credential=self.program_credential)
+
+    def test_data(self):
+        """ Verify that user CredentialAttributeSerializer serialize data correctly."""
+        serialize_data = serializers.UserCredentialAttributeSerializer(self.program_cert_attr)
+        expected = {
+            'name': self.program_cert_attr.name,
+            'value': self.program_cert_attr.value
+        }
+
+        self.assertEqual(serialize_data.data, expected)
+
+
+@ddt.ddt
+class CredentialFieldTests(TestCase):
+    """ CredentialField tests. """
+
+    def setUp(self):
+        super(CredentialFieldTests, self).setUp()
+        self.program_cert = ProgramCertificateFactory()
+        self.field_instance = serializers.CredentialField()
+
+    @ddt.data(
+        {'program_uuid': ''},
+        {'course_id': ''},
+        {'course_id': 404, 'certificate_type': ''},
+    )
+    def test_to_internal_value_with_empty_credential(self, credential_data):
+        """Verify that it will return error message if credential-id attributes are empty."""
+
+        with self.assertRaisesRegexp(ValidationError, 'Credential ID is missing'):
+            self.field_instance.to_internal_value(credential_data)
+
+    def test_to_internal_value_with_invalid_program_credential(self,):
+        """Verify that it will return error message if program-id does not exist in db."""
+
+        with self.assertRaisesRegexp(ValidationError, 'ProgramCertificate matching query does not exist.'):
+            self.field_instance.to_internal_value({'program_uuid': uuid4()})
+
+    def test_to_internal_value_with_in_active_program_credential(self,):
+        """Verify that it will return error message if program is not active in db."""
+        self.program_cert.is_active = False
+        self.program_cert.save()
+
+        with self.assertRaisesRegexp(ValidationError, 'ProgramCertificate matching query does not exist.'):
+            self.field_instance.to_internal_value({'program_uuid': self.program_cert.program_uuid})
+
+    def test_to_internal_value_with_invalid_course_credential(self):
+        """Verify that it will return error message if course-id does not exist in db."""
+
+        with self.assertRaisesRegexp(ValidationError, 'CourseCertificate matching query does not exist.'):
+            self.field_instance.to_internal_value({'course_id': 404, 'certificate_type': 'honor'})
+
+    def test_to_internal_value_with_valid_program_credential(self):
+        """Verify that it will return credential object if program-id found in db."""
+
+        self.assertEqual(
+            self.program_cert,
+            self.field_instance.to_internal_value({'program_uuid': self.program_cert.program_uuid})
+        )
+
+    def test_to_internal_value_with_valid_course_credential(self):
+        """Verify that it will return credential object if course-id and certificate type
+        found in db."""
+
+        course_cert = CourseCertificateFactory()
+        self.assertEqual(
+            course_cert,
+            self.field_instance.to_internal_value({'course_id': course_cert.course_id, 'certificate_type': 'honor'})
+        )
+
+    def test_to_representation_data_with_program(self):
+        """Verify that it will return program certificate credential object in dict format."""
+
+        expected_data = {'program_uuid': self.program_cert.program_uuid, 'credential_id': self.program_cert.id}
+        self.assertEqual(
+            expected_data,
+            self.field_instance.to_representation(
+                self.program_cert
+            )
+        )
+
+    def test_to_representation_with_course(self):
+        """Verify that it will return course certificate credential object in dict format."""
+
+        course_cert = CourseCertificateFactory()
+        expected_data = {
+            'course_id': course_cert.course_id,
+            'credential_id': course_cert.id,
+            'certificate_type': course_cert.certificate_type
+        }
+        self.assertEqual(
+            expected_data,
+            self.field_instance.to_representation(
+                course_cert
+            )
+        )

--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -58,7 +58,6 @@ class UserCredentialSerializerTests(TestCase):
                     'value': self.program_cert_attr.value
                 }
             ],
-            'id': self.program_credential.id,
             'created': self.program_credential.created.strftime(api_settings.DATETIME_FORMAT),
             'modified': self.program_credential.modified.strftime(api_settings.DATETIME_FORMAT),
             'certificate_url': expected_url
@@ -92,7 +91,6 @@ class UserCredentialSerializerTests(TestCase):
                     'value': self.course_cert_attr.value
                 }
             ],
-            'id': self.course_credential.id,
             'created': self.course_credential.created.strftime(api_settings.DATETIME_FORMAT),
             'modified': self.course_credential.modified.strftime(api_settings.DATETIME_FORMAT),
             'certificate_url': expected_url,

--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -3,20 +3,29 @@ Tests for credentials service views.
 """
 from __future__ import unicode_literals
 
-from django.core.urlresolvers import reverse
-from rest_framework.test import APIRequestFactory, APITestCase
+import json
+from uuid import uuid4
 
-from credentials.apps.api.tests.mixins import CredentialViewSetTestsMixin
-from credentials.apps.api.tests.test_views import (
-    BaseUserCredentialViewSetTests, BaseUserCredentialViewSetPermissionsTests, BaseCourseCredentialViewSetTests,
-)
+import ddt
+from django.contrib.auth.models import Group, Permission
+from django.core.urlresolvers import reverse
+from rest_framework.test import APIRequestFactory
+from rest_framework.test import APITestCase
+from testfixtures import LogCapture
+
+from credentials.apps.api.v2.serializers import UserCredentialSerializer
+from credentials.apps.api.v2.tests.mixins import CredentialViewSetTestsMixin
+from credentials.apps.core.constants import Role
+from credentials.apps.core.tests.factories import UserFactory
 from credentials.apps.credentials.models import UserCredential
 from credentials.apps.credentials.tests import factories
 
 JSON_CONTENT_TYPE = 'application/json'
 LOGGER_NAME = 'credentials.apps.credentials.issuers'
-LOGGER_NAME_SERIALIZER = 'credentials.apps.api.serializers'
+LOGGER_NAME_SERIALIZER = 'credentials.apps.api.v2.serializers'
 
+
+# pylint: disable=no-member
 
 class ProgramCredentialViewSetTests(CredentialViewSetTestsMixin, APITestCase):
     """ Tests for ProgramCredentialViewSetTests. """
@@ -27,7 +36,6 @@ class ProgramCredentialViewSetTests(CredentialViewSetTestsMixin, APITestCase):
         super(ProgramCredentialViewSetTests, self).setUp()
 
         self.program_certificate = factories.ProgramCertificateFactory()
-        self.program_id = self.program_certificate.program_id
         self.program_uuid = self.program_certificate.program_uuid
         self.user_credential = factories.UserCredentialFactory.create(credential=self.program_certificate)
         self.request = APIRequestFactory().get('/')
@@ -38,24 +46,6 @@ class ProgramCredentialViewSetTests(CredentialViewSetTestsMixin, APITestCase):
         """
         error_message = {'error': 'A UUID query string parameter is required for filtering program credentials.'}
         self.assert_list_without_id_filter(path=self.list_path, expected=error_message)
-
-    def test_list_without_uuid_but_with_id(self):
-        """ Verify a list end point of program credentials will work with
-        program_uuid filter.
-        """
-        error_message = {'error': 'A UUID query string parameter is required for filtering program credentials.'}
-        self.assert_list_without_id_filter(path=self.list_path,
-                                           data={'program_id': self.program_id},
-                                           expected=error_message)
-
-    def test_list_with_uuid_and_id(self):
-        """ Verify a list end point of program credentials will not work with
-        program_id filter.
-        """
-        error_message = {'error': 'A program_id query string parameter was found in a V2 API request.'}
-        self.assert_list_without_id_filter(path=self.list_path,
-                                           data={'program_uuid': self.program_uuid, 'program_id': self.program_id},
-                                           expected=error_message)
 
     def test_list_with_program_uuid_filter(self):
         """ Verify the list endpoint supports filter data by program_uuid."""
@@ -82,13 +72,582 @@ class ProgramCredentialViewSetTests(CredentialViewSetTestsMixin, APITestCase):
         self.assert_permission_required({'program_uuid': self.program_uuid, 'status': UserCredential.AWARDED})
 
 
-class UserCredentialViewSetTests(BaseUserCredentialViewSetTests, APITestCase):
+@ddt.ddt
+class UserCredentialViewSetTests(APITestCase):
     list_path = reverse("api:v2:usercredential-list")
 
+    def setUp(self):
+        super(UserCredentialViewSetTests, self).setUp()
 
-class UserCredentialViewSetPermissionsTests(BaseUserCredentialViewSetPermissionsTests, APITestCase):
+        self.user = UserFactory()
+        self.client.force_authenticate(self.user)
+
+        self.program_cert = factories.ProgramCertificateFactory()
+        self.user_credential = factories.UserCredentialFactory.create(credential=self.program_cert)
+        self.user_credential_attribute = factories.UserCredentialAttributeFactory.create(
+            user_credential=self.user_credential)
+        self.username = "test_user"
+        self.request = APIRequestFactory().get('/')
+
+    def _add_permission(self, perm):
+        """ DRY helper to add usercredential model permissions to self.user """
+        self.user.user_permissions.add(Permission.objects.get(codename='{}_usercredential'.format(perm)))
+
+    def _attempt_update_user_credential(self, data):
+        """ Helper method that attempts to patch an existing credential object.
+
+        Arguments:
+          data (dict): Data to be converted to JSON and sent to the API.
+
+        Returns:
+          Response: HTTP response from the API.
+        """
+        self._add_permission('change')
+        path = reverse("api:v1:usercredential-detail", args=[self.user_credential.id])
+        return self.client.patch(path=path, data=json.dumps(data), content_type=JSON_CONTENT_TYPE)
+
+    def test_get(self):
+        """ Verify a single user credential is returned. """
+        self._add_permission('view')
+        path = reverse("api:v1:usercredential-detail", args=[self.user_credential.id])
+        response = self.client.get(path)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            UserCredentialSerializer(self.user_credential, context={'request': self.request}).data
+        )
+
+    def test_list_without_username(self):
+        """ Verify a list end point of user credentials will work only with
+        username filter. Otherwise it will return 400.
+        """
+        response = self.client.get(self.list_path)
+        self.assertEqual(response.status_code, 400)
+
+    def test_partial_update(self):
+        """ Verify that only the 'status' field is updated and other fields
+        value remain same.
+        """
+        data = {
+            'id': self.user_credential.id,
+            'status': UserCredential.REVOKED,
+            'download_url': self.user_credential.download_url + 'test'
+        }
+
+        response = self._attempt_update_user_credential(data)
+        self.assertEqual(response.status_code, 200)
+
+        user_credential = UserCredential.objects.get(id=self.user_credential.id)
+        self.assertEqual(user_credential.status, data["status"])
+
+        self.assertNotEqual(user_credential.download_url, data["download_url"])
+        self.assertEqual(user_credential.download_url, self.user_credential.download_url)
+
+    def test_partial_update_authentication(self):
+        """ Verify that patch endpoint allows only authorized users to update
+        user credential.
+        """
+        self.client.logout()
+        data = {
+            "id": self.user_credential.id,
+            "download_url": "dummy-url",
+        }
+
+        path = reverse("api:v1:usercredential-detail", args=[self.user_credential.id])
+        response = self.client.patch(path=path, data=json.dumps(data), content_type=JSON_CONTENT_TYPE)
+        self.assertEqual(response.status_code, 401)
+
+    def _attempt_create_user_credentials(self, data):
+        """ Helper method that attempts to create user credentials.
+
+        Arguments:
+          data (dict): Data to be converted to JSON and sent to the API.
+
+        Returns:
+          Response: HTTP response from the API.
+        """
+        self._add_permission('add')
+        path = self.list_path
+        return self.client.post(path=path, data=json.dumps(data), content_type=JSON_CONTENT_TYPE)
+
+    @ddt.data(
+        ("username", "", "This field may not be blank."),
+        ("credential", "", "Credential ID is missing."),
+        ("credential", {"program_uuid": ""}, "Credential ID is missing."),
+        ("credential", {"course_id": ""}, "Credential ID is missing."),
+    )
+    @ddt.unpack
+    def test_create_with_empty_fields(self, field_name, value, err_msg):
+        """ Verify no UserCredential is created, and HTTP 400 is returned, if
+        required fields are missing.
+        """
+        data = {
+            "username": self.username,
+            "credential": {"program_uuid": self.program_cert.program_uuid.hex},
+            "attributes": [
+                {
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
+                }
+            ]
+        }
+        data.update({field_name: value})
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data.get(field_name),
+            [err_msg]
+        )
+
+    @ddt.data(
+        "username",
+        "credential",
+        "attributes",
+    )
+    def test_create_with_missing_fields(self, field_name):
+        """ Verify no UserCredential is created, and HTTP 400 is returned, if
+        required fields are missing.
+        """
+        data = {
+            "username": self.username,
+            "credential": {"program_uuid": self.program_cert.program_uuid.hex},
+            "attributes": [
+                {
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
+                }
+            ]
+        }
+        del data[field_name]
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data.get(field_name),
+            ['This field is required.']
+        )
+
+    def test_create_with_programcertificate(self):
+        """ Verify the endpoint supports issuing a new ProgramCertificate credential. """
+        program_certificate = factories.ProgramCertificateFactory()
+        data = {
+            "username": self.username,
+            "credential": {
+                "program_uuid": program_certificate.program_uuid.hex
+            },
+            "attributes": [
+                {
+                    "name": self.user_credential_attribute.name,
+                    "value": self.user_credential_attribute.value
+                },
+            ]
+        }
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 201)
+        user_credential = UserCredential.objects.get(username=self.username)
+        self.assertEqual(
+            dict(response.data),
+            dict(UserCredentialSerializer(user_credential, context={'request': self.request}).data)
+        )
+
+    def test_create_authentication(self):
+        """ Verify that the create endpoint of user credential does not allow
+        the unauthorized users to create a new user credential for the program.
+        """
+        self.client.logout()
+        response = self.client.post(path=self.list_path, data={}, content_type=JSON_CONTENT_TYPE)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_create_with_duplicate_attributes(self):
+        """ Verify no UserCredential is created, and HTTP 400 is returned, if
+        there are duplicated attributes.
+        """
+        data = {
+            "username": self.username,
+            "credential": {"program_uuid": self.program_cert.program_uuid.hex},
+            "attributes": [
+                {
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
+                },
+                {
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
+                },
+                {
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
+                },
+                {
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
+                }
+            ]
+        }
+
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.data, {'attributes': ['Attributes cannot be duplicated.']})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(UserCredential.objects.filter(username=self.username).exists())
+
+    def test_create_with_empty_attributes(self):
+        """ Verify no UserCredential is created, and HTTP 400 is returned, if
+        there are some attributes are null.
+        """
+        data = {
+            "username": self.username,
+            "credential": {"program_uuid": self.program_cert.program_uuid.hex},
+            "attributes": [
+                {
+                    "name": "whitelist_reason",
+                    "value": "Reason for whitelisting."
+                },
+                {
+                    "name": "",
+                    "value": "Reason for whitelisting."
+                }
+            ]
+        }
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(UserCredential.objects.filter(username=self.username).exists())
+        self.assertEqual(
+            response.data.get('attributes')[1]['name'][0],
+            'This field may not be blank.'
+        )
+
+    def test_list_with_username_filter(self):
+        """ Verify the list endpoint supports filter data by username."""
+        self._add_permission('view')
+        factories.UserCredentialFactory(username="dummy-user")
+        response = self.client.get(self.list_path, data={'username': self.user_credential.username})
+        self.assertEqual(response.status_code, 200)
+
+        # after filtering it is only one related record
+        expected = UserCredentialSerializer(
+            self.user_credential, context={'request': self.request}
+        ).data
+
+        self.assertEqual(response.data, {'count': 1, 'next': None, 'previous': None, 'results': [expected]})
+
+    def test_list_with_status_filter(self):
+        """ Verify the list endpoint supports filtering by status."""
+        self._add_permission('view')
+        factories.UserCredentialFactory.create_batch(2, status="revoked", username=self.user_credential.username)
+        response = self.client.get(self.list_path, data={'status': self.user_credential.status})
+        self.assertEqual(response.status_code, 400)
+
+        # username and status will return the data.
+        response = self.client.get(self.list_path,
+                                   data={'username': self.user_credential.username, 'status': UserCredential.AWARDED})
+
+        # after filtering it is only one related record
+        expected = UserCredentialSerializer(
+            self.user_credential, context={'request': self.request}
+        ).data
+
+        self.assertEqual(
+            response.data,
+            {'count': 1, 'next': None, 'previous': None, 'results': [expected]}
+        )
+
+    def test_create_with_non_existing_credential(self):
+        """ Verify no UserCredential is created, and HTTP 400 is return if credential
+        id does not exists in db.
+        """
+        program_uuid = str(uuid4())
+        data = {
+            "username": self.username,
+            "credential": {
+                "program_uuid": program_uuid
+            },
+            "attributes": [
+            ]
+        }
+
+        msg = "Credential ID [{cred_id}] for ProgramCertificate matching query does not exist.".format(
+            cred_id=program_uuid
+        )
+
+        # Verify log is captured.
+        with LogCapture(LOGGER_NAME_SERIALIZER) as l:
+            response = self._attempt_create_user_credentials(data)
+            l.check((LOGGER_NAME_SERIALIZER, 'ERROR', msg))
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_reissue_the_user_credentials(self):
+        """ Verify that, if a user has already been issued a credential, further
+        attempts to issue the same credential will NOT create a new credential,
+        but its attributes will be updated if provided.
+        """
+        attributes = [
+            {"name": "whitelist_reason", "value": "Reason for whitelisting."},
+            {"name": "grade", "value": "0.85"}
+        ]
+
+        data = {
+            "username": self.username,
+            "credential": {
+                "program_uuid": self.program_cert.program_uuid.hex
+            },
+            "attributes": attributes
+        }
+
+        # issue first credential for the user
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 201)
+        self._assert_usercredential_fields(response, self.username, attributes)
+
+        # change the attributes value
+        data["attributes"][0]["value"] = "New reason for whitelisting."
+        data["attributes"][1]["value"] = "0.8"
+
+        # try to issue credential again for the same user but with different attribute values and
+        # test that the existing record for user credential has been updated with new attribute values
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 201)
+        self._assert_usercredential_fields(response, self.username, attributes)
+
+    @ddt.data(
+        [{"name": "whitelist_reason", "value": "Reason for whitelisting."}],
+        [
+            {"name": "whitelist_reason", "value": "Reason for whitelisting."},
+            {"name": "grade", "value": "0.85"},
+        ],
+    )
+    def test_create_with_duplicate_attrs(self, attributes):
+        """ Verify that, if a user has a credential with attributes
+        then its values can be updated.
+        """
+        # create credential with attributes
+        user_credential = factories.UserCredentialFactory.create(
+            username=self.username,
+            credential=self.program_cert
+        )
+        factories.UserCredentialAttributeFactory(
+            user_credential=user_credential, name="whitelist_reason", value="Reason for whitelisting."
+        )
+        self.assertTrue(user_credential.attributes.exists())
+
+        data = {
+            "username": self.username,
+            "credential": {
+                "program_uuid": self.program_cert.program_uuid.hex
+            },
+            "attributes": attributes
+        }
+
+        # 2nd attempt to create credential with attributes.
+        response = self._attempt_create_user_credentials(data)
+        self.assertEqual(response.status_code, 201)
+        self._assert_usercredential_fields(response, self.username, attributes)
+
+    def _assert_usercredential_fields(self, response, username, expected_attrs):
+        """ Verify the fields on a UserCredential object match expectations. """
+
+        user_credential = UserCredential.objects.filter(username=username)
+        expected = UserCredentialSerializer(user_credential[0], context={'request': self.request}).data
+
+        self.assertEqual(user_credential.count(), 1)
+        self.assertEqual(response.data, expected)
+
+        actual_attributes = [{"name": attr.name, "value": attr.value} for attr in user_credential[0].attributes.all()]
+        self.assertEqual(actual_attributes, expected_attrs)
+
+    def test_create_with_inactive_program_certificate(self):
+        """ Verify the endpoint throws error if Program is inactive. """
+        program_certificate = factories.ProgramCertificateFactory(is_active=False)
+        program_uuid = str(program_certificate.program_uuid)
+        data = {
+            "username": self.username,
+            "credential": {
+                "program_uuid": program_uuid
+            },
+            "attributes": [
+                {
+                    "name": self.user_credential_attribute.name,
+                    "value": self.user_credential_attribute.value
+                },
+            ]
+        }
+
+        msg = "Credential ID [{cred_id}] for ProgramCertificate matching query does not exist.".format(
+            cred_id=program_uuid
+        )
+
+        # Verify log is captured.
+        with LogCapture(LOGGER_NAME_SERIALIZER) as l:
+            response = self._attempt_create_user_credentials(data)
+            l.check((LOGGER_NAME_SERIALIZER, 'ERROR', msg))
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_users_lists_access_by_authenticated_users(self):
+        """ Verify the list endpoint can be access by authenticated users only."""
+        # logout the user
+        self.client.logout()
+        response = self.client.get(self.list_path, data={'username': self.user_credential.username})
+        self.assertEqual(response.status_code, 401)
+
+
+@ddt.ddt
+class UserCredentialViewSetPermissionsTests(APITestCase):
     list_path = reverse("api:v2:usercredential-list")
 
+    def make_user(self, group=None, perm=None, **kwargs):
+        """ DRY helper to create users with specific groups and/or permissions. """
+        user = UserFactory(**kwargs)
+        if group:
+            user.groups.add(Group.objects.get(name=group))
+        if perm:
+            user.user_permissions.add(Permission.objects.get(codename='{}_usercredential'.format(perm)))
+        return user
 
-class CourseCredentialViewSetTests(BaseCourseCredentialViewSetTests, CredentialViewSetTestsMixin, APITestCase):
+    @ddt.data(
+        ({'group': Role.ADMINS}, 200),
+        ({'perm': 'view'}, 200),
+        ({'perm': 'add'}, 404),
+        ({'perm': 'change'}, 404),
+        ({'username': 'test-user'}, 200),
+        ({'username': 'TeSt-uSeR'}, 200),
+        ({'username': 'other'}, 404),
+    )
+    @ddt.unpack
+    def test_list(self, user_kwargs, expected_status):
+        """
+        The list method (GET) requires either 'view' permission, or for the
+        'username' query parameter to match that of the requesting user.
+        """
+
+        self.client.force_authenticate(self.make_user(**user_kwargs))
+        response = self.client.get(self.list_path, {'username': 'test-user'})
+        self.assertEqual(response.status_code, expected_status)
+
+    @ddt.data(
+        ({'group': Role.ADMINS}, 201),
+        ({'perm': 'add'}, 201),
+        ({'perm': 'view'}, 403),
+        ({'perm': 'change'}, 403),
+        ({}, 403),
+        ({'username': 'test-user'}, 403),
+    )
+    @ddt.unpack
+    def test_create(self, user_kwargs, expected_status):
+        """
+        The creation (POST) method requires the 'add' permission.
+        """
+        program_certificate = factories.ProgramCertificateFactory()
+        post_data = {
+            'username': 'test-user',
+            'credential': {
+                'program_uuid': program_certificate.program_uuid.hex
+            },
+            'attributes': [],
+        }
+
+        self.client.force_authenticate(self.make_user(**user_kwargs))
+        response = self.client.post(self.list_path, data=json.dumps(post_data), content_type=JSON_CONTENT_TYPE)
+        self.assertEqual(response.status_code, expected_status)
+
+    @ddt.data(
+        ({'group': Role.ADMINS}, 200),
+        ({'perm': 'view'}, 200),
+        ({'perm': 'add'}, 404),
+        ({'perm': 'change'}, 404),
+        ({'username': 'test-user'}, 200),
+        ({'username': 'TeSt-uSeR'}, 200),
+        ({'username': 'other-user'}, 404),
+    )
+    @ddt.unpack
+    def test_retrieve(self, user_kwargs, expected_status):
+        """
+        The retrieve (GET) method requires the 'view' permission, or for the
+        requested object to be associated with the username of the requesting
+        user.
+        """
+        program_cert = factories.ProgramCertificateFactory()
+        user_credential = factories.UserCredentialFactory.create(credential=program_cert, username='test-user')
+        detail_path = reverse("api:v1:usercredential-detail", args=[user_credential.id])
+
+        self.client.force_authenticate(self.make_user(**user_kwargs))
+        response = self.client.get(detail_path)
+        self.assertEqual(response.status_code, expected_status)
+
+    @ddt.data(
+        ({'group': Role.ADMINS}, 200),
+        ({'perm': 'view'}, 403),
+        ({'perm': 'add'}, 403),
+        ({'perm': 'change'}, 200),
+        ({'username': 'test-user'}, 403),
+        ({}, 403),
+    )
+    @ddt.unpack
+    def test_partial_update(self, user_kwargs, expected_status):
+        """
+        The partial update (PATCH) method requires the 'change' permission.
+        """
+        program_cert = factories.ProgramCertificateFactory()
+        user_credential = factories.UserCredentialFactory.create(credential=program_cert, username='test-user')
+        detail_path = reverse("api:v1:usercredential-detail", args=[user_credential.id])
+        post_data = {
+            'username': 'test-user',
+            'credential': {
+                'program_uuid': program_cert.program_uuid.hex
+            },
+            'attributes': [{'name': 'dummy-attr-name', 'value': 'dummy-attr-value'}],
+        }
+        self.client.force_authenticate(self.make_user(**user_kwargs))
+        response = self.client.patch(path=detail_path, data=json.dumps(post_data), content_type=JSON_CONTENT_TYPE)
+        self.assertEqual(response.status_code, expected_status)
+
+
+class CourseCredentialViewSetTests(CredentialViewSetTestsMixin, APITestCase):
     list_path = reverse("api:v2:coursecredential-list")
+
+    def setUp(self):
+        super(CourseCredentialViewSetTests, self).setUp()
+
+        self.course_certificate = factories.CourseCertificateFactory()
+        self.course_id = self.course_certificate.course_id
+        self.user_credential = factories.UserCredentialFactory.create(credential=self.course_certificate)
+
+    def test_list_without_course_id(self):
+        """ Verify a list end point of course credentials will work only with
+        course_id filter. Otherwise it will return 400.
+        """
+        self.assert_list_without_id_filter(self.list_path, {
+            'error': 'A course_id query string parameter is required for filtering course credentials.'
+        })
+
+    def test_list_with_course_id(self):
+        """ Verify the list endpoint supports filter data by course_id."""
+        course_cert = factories.CourseCertificateFactory(course_id="fake-id")
+        factories.UserCredentialFactory.create(credential=course_cert)
+        self.assert_list_with_id_filter(data={'course_id': self.course_id})
+
+    def test_list_with_status_filter(self):
+        """ Verify the list endpoint supports filtering by status."""
+        factories.UserCredentialFactory.create_batch(2, status="revoked", username=self.user_credential.username)
+        self.assert_list_with_status_filter(data={'course_id': self.course_id, 'status': UserCredential.AWARDED})
+
+    def test_list_with_certificate_type(self):
+        """ Verify the list endpoint supports filtering by certificate_type."""
+        course_cert = factories.CourseCertificateFactory(certificate_type="verified")
+        factories.UserCredentialFactory.create(credential=course_cert)
+
+        # course_id is mandatory
+        data = {'course_id': self.course_id, 'certificate_type': self.course_certificate.certificate_type}
+        response = self.client.get(self.list_path, data=data)
+
+        # after filtering it is only one related record
+        expected = UserCredentialSerializer(self.user_credential, context={'request': self.request}).data
+        self.assertEqual(
+            json.loads(response.content),
+            {'count': 1, 'next': None, 'previous': None, 'results': [expected]}
+        )
+
+    def test_permission_required(self):
+        """ Verify that requests require explicit model permissions. """
+        self.assert_permission_required({'course_id': self.course_id, 'status': UserCredential.AWARDED})

--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -103,13 +103,13 @@ class UserCredentialViewSetTests(APITestCase):
           Response: HTTP response from the API.
         """
         self._add_permission('change')
-        path = reverse("api:v1:usercredential-detail", args=[self.user_credential.id])
+        path = reverse("api:v2:usercredential-detail", args=[self.user_credential.uuid])
         return self.client.patch(path=path, data=json.dumps(data), content_type=JSON_CONTENT_TYPE)
 
     def test_get(self):
         """ Verify a single user credential is returned. """
         self._add_permission('view')
-        path = reverse("api:v1:usercredential-detail", args=[self.user_credential.id])
+        path = reverse("api:v2:usercredential-detail", args=[self.user_credential.uuid])
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -153,7 +153,7 @@ class UserCredentialViewSetTests(APITestCase):
             "download_url": "dummy-url",
         }
 
-        path = reverse("api:v1:usercredential-detail", args=[self.user_credential.id])
+        path = reverse("api:v2:usercredential-detail", args=[self.user_credential.uuid])
         response = self.client.patch(path=path, data=json.dumps(data), content_type=JSON_CONTENT_TYPE)
         self.assertEqual(response.status_code, 401)
 
@@ -245,8 +245,8 @@ class UserCredentialViewSetTests(APITestCase):
         self.assertEqual(response.status_code, 201)
         user_credential = UserCredential.objects.get(username=self.username)
         self.assertEqual(
-            dict(response.data),
-            dict(UserCredentialSerializer(user_credential, context={'request': self.request}).data)
+            response.data,
+            UserCredentialSerializer(user_credential, context={'request': self.request}).data
         )
 
     def test_create_authentication(self):
@@ -451,7 +451,7 @@ class UserCredentialViewSetTests(APITestCase):
         expected = UserCredentialSerializer(user_credential[0], context={'request': self.request}).data
 
         self.assertEqual(user_credential.count(), 1)
-        self.assertEqual(response.data, expected)
+        self.assertDictEqual(response.data, expected)
 
         actual_attributes = [{"name": attr.name, "value": attr.value} for attr in user_credential[0].attributes.all()]
         self.assertEqual(actual_attributes, expected_attrs)
@@ -569,7 +569,7 @@ class UserCredentialViewSetPermissionsTests(APITestCase):
         """
         program_cert = factories.ProgramCertificateFactory()
         user_credential = factories.UserCredentialFactory.create(credential=program_cert, username='test-user')
-        detail_path = reverse("api:v1:usercredential-detail", args=[user_credential.id])
+        detail_path = reverse("api:v2:usercredential-detail", args=[user_credential.uuid])
 
         self.client.force_authenticate(self.make_user(**user_kwargs))
         response = self.client.get(detail_path)
@@ -590,7 +590,7 @@ class UserCredentialViewSetPermissionsTests(APITestCase):
         """
         program_cert = factories.ProgramCertificateFactory()
         user_credential = factories.UserCredentialFactory.create(credential=program_cert, username='test-user')
-        detail_path = reverse("api:v1:usercredential-detail", args=[user_credential.id])
+        detail_path = reverse("api:v2:usercredential-detail", args=[user_credential.uuid])
         post_data = {
             'username': 'test-user',
             'credential': {

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -16,10 +16,11 @@ log = logging.getLogger(__name__)
 class UserCredentialViewSet(viewsets.ModelViewSet):
     """ UserCredentials endpoints. """
 
-    queryset = UserCredential.objects.all()
+    lookup_field = 'uuid'
     filter_fields = ('username', 'status')
-    serializer_class = UserCredentialSerializer
     permission_classes = (UserCredentialViewSetPermissions,)
+    queryset = UserCredential.objects.all()
+    serializer_class = UserCredentialSerializer
 
     def list(self, request, *args, **kwargs):
         if not request.query_params.get('username'):

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -6,8 +6,8 @@ from rest_framework.exceptions import ValidationError
 
 from credentials.apps.api.filters import CourseFilter
 from credentials.apps.api.permissions import UserCredentialViewSetPermissions
-from credentials.apps.api.serializers import UserCredentialCreationSerializer, UserCredentialSerializer
 from credentials.apps.api.v2.filters import UserCredentialFilter
+from credentials.apps.api.v2.serializers import UserCredentialCreationSerializer, UserCredentialSerializer
 from credentials.apps.credentials.models import UserCredential
 
 log = logging.getLogger(__name__)
@@ -51,11 +51,6 @@ class ProgramsCredentialsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
         if not self.request.query_params.get('program_uuid'):
             raise ValidationError(
                 {'error': 'A UUID query string parameter is required for filtering program credentials.'})
-
-        # Confirmation that we are not supplying both parameters. We should only be providing the program_uuid in V2
-        if self.request.query_params.get('program_id'):
-            raise ValidationError(
-                {'error': 'A program_id query string parameter was found in a V2 API request.'})
 
         # pylint: disable=maybe-no-member
         return super(ProgramsCredentialsViewSet, self).list(request, *args, **kwargs)

--- a/credentials/apps/core/tests/mixins.py
+++ b/credentials/apps/core/tests/mixins.py
@@ -19,7 +19,7 @@ class SiteMixin(object):
         domain = 'testserver.fake'
         self.client = self.client_class(SERVER_NAME=domain)
 
-        Site.objects.all().delete()
+        Site.objects.all().delete()  # pylint: disable=no-member
         site_configuration = SiteConfigurationFactory(
             site__domain=domain,
             site__id=settings.SITE_ID

--- a/credentials/apps/credentials/migrations/0005_auto_20170111_0441.py
+++ b/credentials/apps/credentials/migrations/0005_auto_20170111_0441.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('credentials', '0004_auto_20161129_0627'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='usercredential',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, unique=True, editable=False),
+        ),
+    ]

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -197,7 +197,7 @@ class UserCredential(TimeStampedModel):
         max_length=255, blank=True, null=True,
         help_text=_('Download URL for the PDFs.')
     )
-    uuid = models.UUIDField(default=uuid.uuid4, editable=False)
+    uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
 
     class Meta(object):
         unique_together = (('username', 'credential_content_type', 'credential_id'),)

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -271,7 +271,7 @@ class ProgramCertificate(AbstractCertificate):
         if program:
             return program
 
-        client = self.site.siteconfiguration.catalog_api_client
+        client = self.site.siteconfiguration.catalog_api_client  # pylint:disable=no-member
         program = client.programs(program_uuid).get()
         cache.set(cache_key, program, settings.PROGRAMS_CACHE_TTL)
 


### PR DESCRIPTION
API v2 should only be utilizing program UUID when referring to programs. This fixes the references made for UserCredential creation.

ECOM-6482