### PR TITLE
Avoid escaping signatory data

### DIFF
--- a/credentials/templates/credentials/program.html
+++ b/credentials/templates/credentials/program.html
@@ -108,8 +108,10 @@
                                         <h4 class="signatory-name">{{ signatory.name }}</h4>
 
                                         <p class="signatory-credentials">
+                                            {% autoescape off %}
                                             <span class="role">{{ signatory.title }}</span>
                                                 <span class="organization">{% firstof signatory.organization_name_override certificate_context.program_details.organizations.0.name %}</span>
+                                            {% endautoescape %}
                                         </p>
                                     </div>
                                     {% endfor %}


### PR DESCRIPTION
Site operators control signatory data (i.e., it's not possible for a user to create or modify this content). Not escaping this prevents names like 'King's College' from becoming 'King&#39;s College' in the rendered credential.

@edx/ecommerce FYI. I caught this after seeing https://travis-ci.org/edx/credentials/builds/190417135#L1134 failing on master. Thanks Faker!