### PR TITLE
Corrected pagination class for API v2

### DIFF
--- a/credentials/apps/api/v1/views.py
+++ b/credentials/apps/api/v1/views.py
@@ -3,6 +3,7 @@ import logging
 from django.http import Http404
 from rest_framework import mixins, viewsets
 from rest_framework.exceptions import ValidationError
+from rest_framework.pagination import LimitOffsetPagination
 
 from credentials.apps.api.filters import CourseFilter
 from credentials.apps.api.permissions import UserCredentialViewSetPermissions
@@ -19,6 +20,7 @@ class UserCredentialViewSet(viewsets.ModelViewSet):
     queryset = UserCredential.objects.all()
     filter_fields = ('username', 'status')
     serializer_class = UserCredentialSerializer
+    pagination_class = LimitOffsetPagination
     permission_classes = (UserCredentialViewSetPermissions,)
 
     def list(self, request, *args, **kwargs):
@@ -44,6 +46,7 @@ class ProgramsCredentialsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
     """It will return the all credentials for programs."""
     queryset = UserCredential.objects.all()
     filter_class = UserCredentialFilter
+    pagination_class = LimitOffsetPagination
     serializer_class = UserCredentialSerializer
 
     def list(self, request, *args, **kwargs):
@@ -59,6 +62,7 @@ class CourseCredentialsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     """It will return the all credentials for courses."""
     queryset = UserCredential.objects.all()
     filter_class = CourseFilter
+    pagination_class = LimitOffsetPagination
     serializer_class = UserCredentialSerializer
 
     def list(self, request, *args, **kwargs):

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -281,7 +281,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.DjangoModelPermissions',),
     'PAGE_SIZE': 20,
     'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%SZ'


### PR DESCRIPTION
All of our APIs should use page number pagination. This is now the default for the project. API v1 still retains limit-offset pagination to avoid breaking existing clients.

ECOM-6808