### PR TITLE
Can't concatenate lists to tuples.

### DIFF
--- a/credentials/settings/production.py
+++ b/credentials/settings/production.py
@@ -29,7 +29,7 @@ with open(CONFIG_FILE) as f:
     vars().update(FILE_STORAGE_BACKEND)
 
 if 'EXTRA_APPS' in locals():
-    INSTALLED_APPS += EXTRA_APPS
+    INSTALLED_APPS += tuple(EXTRA_APPS)
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),


### PR DESCRIPTION
This broke in our [CI environment yesterday](http://jenkins.edx.org:8080/job/ansible-provision/10892/console) with the following error:

`TypeError: can only concatenate tuple (not "list") to tuple`

@MatthewPiatetsky @clintonb Please review.  Also, can someone on your team look at why this slipped through other forms of testing?