### PR TITLE
Adding exception throwing if logo image is missing

### DIFF
--- a/credentials/apps/credentials/exceptions.py
+++ b/credentials/apps/credentials/exceptions.py
@@ -1,0 +1,5 @@
+class MissingCertificateLogoError(Exception):
+    """ Raised when a Program fetched as part of a program certificate configuration
+     has an organization without a defined certificate logo image url
+    """
+    pass

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -236,7 +236,8 @@ class CourseCertificate(AbstractCertificate):
         verbose_name = "Course certificate configuration"
 
 
-OrganizationDetails = namedtuple('OrganizationDetails', ('uuid', 'key', 'name', 'display_name', 'logo_image_url'))
+OrganizationDetails = namedtuple('OrganizationDetails', ('uuid', 'key', 'name', 'display_name',
+                                                         'certificate_logo_image_url'))
 ProgramDetails = namedtuple('ProgramDetails', ('uuid', 'title', 'type', 'course_count', 'organizations'))
 
 
@@ -294,7 +295,7 @@ class ProgramCertificate(AbstractCertificate):
                 key=organization['key'],
                 name=organization['name'],
                 display_name=organization['name'] if self.use_org_name else organization['key'],
-                logo_image_url=organization['logo_image_url']
+                certificate_logo_image_url=organization['certificate_logo_image_url']
             ))
 
         return ProgramDetails(

--- a/credentials/apps/credentials/tests/test_models.py
+++ b/credentials/apps/credentials/tests/test_models.py
@@ -167,14 +167,14 @@ class ProgramCertificateTests(SiteMixin, TestCase):
                     key='ACMEx',
                     name='ACME University',
                     display_name='ACME University' if use_org_name else 'ACMEx',
-                    logo_image_url='http://example.com/acme.jpg'
+                    certificate_logo_image_url='http://example.com/acme.jpg'
                 ),
                 OrganizationDetails(
                     uuid=uuid.uuid4().hex,
                     key='FakeX',
                     name='Fake University',
                     display_name='Fake University' if use_org_name else 'FakeX',
-                    logo_image_url='http://example.com/fakex.jpg'
+                    certificate_logo_image_url='http://example.com/fakex.jpg'
                 )
             ]
         )
@@ -189,7 +189,7 @@ class ProgramCertificateTests(SiteMixin, TestCase):
                     'uuid': organization.uuid,
                     'key': organization.key,
                     'name': organization.name,
-                    'logo_image_url': organization.logo_image_url,
+                    'certificate_logo_image_url': organization.certificate_logo_image_url,
 
                 } for organization in expected.organizations
             ],
@@ -217,7 +217,7 @@ class ProgramCertificateTests(SiteMixin, TestCase):
                     'uuid': uuid.uuid4().hex,
                     'key': 'FakeX',
                     'name': 'Fake University',
-                    'logo_image_url': 'https://static.fake.edu/logo.png',
+                    'certificate_logo_image_url': 'https://static.fake.edu/logo.png',
 
                 }
             ],

--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -9,6 +9,7 @@ from django.template.defaultfilters import slugify
 from django.utils import timezone
 from django.views.generic import TemplateView
 
+from credentials.apps.credentials.exceptions import MissingCertificateLogoError
 from credentials.apps.credentials.models import UserCredential, ProgramCertificate, ProgramDetails, OrganizationDetails
 from credentials.apps.credentials.utils import get_user_data
 
@@ -29,6 +30,12 @@ class RenderCredential(TemplateView):
             uuid=kwargs.get('uuid'),
             status=UserCredential.AWARDED
         )
+
+        program_details = user_credential.credential.program_details
+        for organization in program_details.organizations:
+            if not organization.certificate_logo_image_url:
+                raise MissingCertificateLogoError('No certificate image logo defined for program: [{program_uuid}]'.
+                                                  format(program_uuid=program_details.uuid))
 
         # get the model class according the credential content type.
         # It will be use to call the appropriate method for rendering.
@@ -82,7 +89,7 @@ class ExampleCredential(TemplateView):
                 key='ExampleX',
                 name='Example University',
                 display_name='Absolutely Fake University',
-                logo_image_url='http://placehold.it/204x204'
+                certificate_logo_image_url='http://placehold.it/204x204'
             )]
         )
 

--- a/credentials/templates/credentials/programs/base.html
+++ b/credentials/templates/credentials/programs/base.html
@@ -47,7 +47,7 @@
                             <ul class="wrapper-orgs list-orgs">
                                 <li class="wrapper-organization">
                                     <div class="organization">
-                                        <img class="organization-logo" src="{{ certificate_context.program_details.organizations.0.logo_image_url }}" alt="{{ certificate_context.program_details.organizations.0.name }} {% trans 'logo' %}">
+                                        <img class="organization-logo" src="{{ certificate_context.program_details.organizations.0.certificate_logo_image_url }}" alt="{{ certificate_context.program_details.organizations.0.name }} {% trans 'logo' %}">
                                     </div>
                                 </li>
                             </ul>


### PR DESCRIPTION
ECOM-6863

Adding exception if logo image is missing in the program details.  This is expected to only be shown to PCs and edX staff during certificate configuration and is not likely to be learner-facing.

@edx/ecommerce for review