### PR TITLE
Upgrade nodeenv to 1.1.1

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,5 +6,5 @@ gevent==1.0.2
 gunicorn==19.3.0
 MySQL-python==1.2.5
 newrelic==2.72.1.53
-nodeenv==0.13.6
+nodeenv==1.1.1
 PyYAML==3.11


### PR DESCRIPTION
This fixes a bug in the Ansible provisioning process where an existing nodeenv could fail to be created when the node version was changed.

See edx/configuration#3648 and ekalinin/nodeenv#183 for more details.