### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-waffle==0.11.1
 djangorestframework==3.4.7
 djangorestframework-jwt==1.9.0
 edx-auth-backends==0.7.0
-edx-django-release-util==0.2.0
+edx-django-release-util==0.2.1
 edx-drf-extensions==1.2.2
 edx-opaque-keys==0.4
 edx-rest-api-client==1.7.1


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.2.1.

@edx-ops/pipeline-team Please review and tag appropriate parties.