### PR TITLE
[ECOM-7345] User Credential API endpoint should be site aware

### DIFF
--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.db.models import Q
 from rest_framework import viewsets
 from rest_framework.response import Response
 
@@ -15,8 +16,13 @@ class CredentialViewSet(viewsets.ModelViewSet):
     filter_class = UserCredentialFilter
     lookup_field = 'uuid'
     permission_classes = (UserCredentialPermissions,)
-    queryset = UserCredential.objects.all()
     serializer_class = UserCredentialSerializer
+
+    def get_queryset(self):
+        # We have to filter on the explicit credential models
+        # because we cannot set a GenericRelation field on the Site model.
+        site = self.request.site
+        return UserCredential.objects.filter(Q(program_credentials__site=site) | Q(course_credentials__site=site))
 
     def create(self, request, *args, **kwargs):
         """ Create a new credential.


### PR DESCRIPTION
@mjfrey @vkaracic @iivic This is the PR for making the User Credential API endpoint (WL) site aware.

The only reason this is marked as WIP is the fact that we still don't know to what extent should the endpoint be site-aware. I made it absolutely site-aware, which means that it doesn't matter which user sends the request to the endpoint, but from which Site the request is being sent from.
If we decide to remove the Site awareness for a specific use case, this PR can easily be modified.

JIRA ticket: https://openedx.atlassian.net/browse/ECOM-7345