### PR TITLE
Updated makefile to only pull reviewed strings from Transifex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ compile_translations:
 fake_translations: extract_translations dummy_translations compile_translations
 
 pull_translations:
-	tx pull -af
+	tx pull -af --mode reviewed
 
 push_translations:
 	tx push -s


### PR DESCRIPTION
Updated makefile to only pull reviewed strings from Transifex.

Verification of upcoming commit that will run by the jenkins job. https://github.com/edx/credentials/pull/181

Context:
 
The jenkins job that automatically pulls and merges translations from Transifex, but will create a PR in case it requires manual resolution. https://github.com/edx/credentials/pull/167 . Rather than manually fixing each string (there many of them), this PR changes the pull step to only pull strings that have been reviewed. Since there are no user facing translations in use, the changes https://github.com/edx/credentials/pull/181 should not effect the UX when removing the non-reviewed translations. The process for reviewing translations does not have to be resolved in this PR. By only pulling reviewed strings, there will be less overhead for fixing strings in this step of the process.