### PR TITLE
Removed jQuery

### DIFF
--- a/credentials/static/js/sharing.js
+++ b/credentials/static/js/sharing.js
@@ -1,29 +1,37 @@
-import $ from "jquery";
+var facebookAppId = window.edx.facebook.appId;
 
-$(document).ready(function () {
-    var facebookAppId = window.edx.facebook.appId;
+if (facebookAppId) {
+    window.fbAsyncInit = function () {
+        var shareButton = document.getElementsByClassName('action-facebook')[0];
 
-    if (facebookAppId) {
-        $.ajaxSetup({cache: true});
-        $.getScript('//connect.facebook.net/en_US/sdk.js', function () {
-            var $shareButton = $('.action-facebook');
-
-            FB.init({
-                appId: facebookAppId,
-                version: 'v2.7'
-            });
-
-            // Activate the sharing button
-            $shareButton.removeAttr('disabled');
-
-            $shareButton.click(function () {
-                FB.ui({
-                    method: 'share',
-                    href: window.edx.facebook.href
-                }, function (response) {
-                    // TODO Log to Segment. The response will be empty since we don't use Facebook login.
-                });
-            });
+        FB.init({
+            appId: facebookAppId,
+            xfbml: true,
+            version: 'v2.8'
         });
-    }
-});
+        FB.AppEvents.logPageView();
+
+        // Activate the sharing button
+        shareButton.removeAttribute('disabled');
+
+        shareButton.onclick = function () {
+            FB.ui({
+                method: 'share',
+                href: window.edx.facebook.href
+            }, function (response) {
+                // TODO Log to Segment. The response will be empty since we don't use Facebook login.
+            });
+        };
+    };
+
+    (function (d, s, id) {
+        var js, fjs = d.getElementsByTagName(s)[0];
+        if (d.getElementById(id)) {
+            return;
+        }
+        js = d.createElement(s);
+        js.id = id;
+        js.src = "//connect.facebook.net/en_US/sdk.js";
+        fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "file-loader": "^0.10.1",
     "font-awesome": "^4.7.0",
     "imports-loader": "^0.7.1",
-    "jquery": "^3.1.1",
     "node-sass": "^4.5.0",
     "sass-loader": "^6.0.3",
     "style-loader": "^0.13.2",


### PR DESCRIPTION
Facebook offers an integration method that does not rely on jQuery. This integration is now used, and jQuery has been removed.

ECOM-6578