### PR TITLE
Fix use of deprecated assert method

### DIFF
--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -32,7 +32,7 @@ class CredentialFieldTests(TestCase):
     def test_to_internal_value_with_empty_program_uuid(self):
         """ Verify an error is raised if no program UUID is provided. """
 
-        with self.assertRaisesRegexp(ValidationError, 'Credential identifier is missing'):
+        with self.assertRaisesRegex(ValidationError, 'Credential identifier is missing'):
             self.field_instance.to_internal_value({'program_uuid': ''})
 
     def test_to_internal_value_with_invalid_program_uuid(self, ):

--- a/credentials/apps/core/tests/test_commands.py
+++ b/credentials/apps/core/tests/test_commands.py
@@ -161,7 +161,7 @@ class CreateOrUpdateSiteCommandTests(SiteMixin, TestCase):
         kwargs = {'enable_facebook_sharing': True}
 
         # pylint: disable=no-member
-        with self.assertRaisesRegexp(CommandError, 'A Facebook app ID must be supplied to enable Facebook sharing'):
+        with self.assertRaisesRegex(CommandError, 'A Facebook app ID must be supplied to enable Facebook sharing'):
             self._call_command(site_domain=self.site.domain, site_name=self.site.name, **kwargs)
 
         kwargs['facebook_app_id'] = self.faker.word()

--- a/credentials/apps/credentials/tests/test_views.py
+++ b/credentials/apps/credentials/tests/test_views.py
@@ -183,7 +183,7 @@ class RenderCredentialPageTests(SiteMixin, TestCase):
     @responses.activate
     def test_logo_missing_exception(self):
 
-        with self.assertRaisesRegexp(MissingCertificateLogoError, 'No certificate image logo defined for program'):
+        with self.assertRaisesRegex(MissingCertificateLogoError, 'No certificate image logo defined for program'):
             self._render_user_credential(use_proper_logo_url=False)
 
 


### PR DESCRIPTION
assertRaisesRegexp() was renamed to assertRaisesRegex()

Unblocks https://github.com/edx/credentials/pull/202.