### PR TITLE
Fixes for multi-tenancy

### DIFF
--- a/credentials/apps/core/views.py
+++ b/credentials/apps/core/views.py
@@ -85,14 +85,11 @@ class AutoAuth(View):
         return redirect('/')
 
 
-def render_500(request, template_name='500.html'):
+def render_500(request, template_name='500.html'):  # pylint: disable=unused-argument
     """ Custom 500 error handler.
 
     Arguments:
         template_name (template): Template for rendering
     """
-    context = {
-        'site': request.site
-    }
-    response = render_to_response(template_name, context, status=500)
+    response = render_to_response(template_name, status=500)
     return response

--- a/credentials/apps/edx_django_extensions/tests/test_views.py
+++ b/credentials/apps/edx_django_extensions/tests/test_views.py
@@ -4,9 +4,10 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 
 from credentials.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from credentials.apps.core.tests.mixins import SiteMixin
 
 
-class ManagementViewTests(TestCase):
+class ManagementViewTests(SiteMixin, TestCase):
     path = reverse('management:index')
 
     def setUp(self):

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -19,7 +19,8 @@ DEBUG = False
 ALLOWED_HOSTS = []
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#site-id
-SITE_ID = 1
+# NOTE (CCB): This is intentionally set to None, forcing Django to use middleware to determine the site.
+SITE_ID = None
 
 # Application definition
 

--- a/credentials/settings/production.py
+++ b/credentials/settings/production.py
@@ -54,6 +54,3 @@ DB_OVERRIDES = dict(
 
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
-
-# TODO Move this to configuration...if it works.
-USE_X_FORWARDED_HOST = True

--- a/credentials/templates/500.html
+++ b/credentials/templates/500.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% load staticfiles %}
 
-{% block title %} {% trans "Server Error" %} | {% firstof site.name platform_name %}{% endblock title %}
+{% block title %}
+  {% trans "Server Error" %}
+{% endblock title %}
 
 {% block wrapper_content %}
-    <div>
-        <h1>{% trans "Server Error" %}</h1>
-    </div>
+  <div>
+    <h1>{% trans "Server Error" %}</h1>
+  </div>
 {% endblock %}


### PR DESCRIPTION
- Removed USE_X_FORWARDED_HOST setting, since it is not the solution to our problem
- Set SITE_ID to None to ensure the middleware is always used to determine the current site

LEARNER-516