### PR TITLE
Added middleware to exempt the health check from site checks

### DIFF
--- a/credentials/apps/core/middleware.py
+++ b/credentials/apps/core/middleware.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django.contrib.sites.middleware import CurrentSiteMiddleware as DjangoCurrentSiteMiddleware
+
+
+class CurrentSiteMiddleware(DjangoCurrentSiteMiddleware):
+    """ This middleware behaves the same as the default CurrentSiteMiddleware,
+    except certain paths can be exempted from the site requirement. This is useful
+    for health checks on load balancers which might have numerous dynamic hostnames.
+    We can avoid the hassle of having to update configuration for every new deployment.
+    """
+
+    def process_request(self, request):
+        if request.path not in settings.CURRENT_SITE_MIDDLEWARE_EXEMPTED_PATHS:
+            super().process_request(request)

--- a/credentials/apps/core/tests/test_middleware.py
+++ b/credentials/apps/core/tests/test_middleware.py
@@ -1,0 +1,22 @@
+from django.contrib.sites.models import Site
+from django.test import RequestFactory, TestCase, override_settings
+
+from credentials.apps.core.middleware import CurrentSiteMiddleware
+
+
+class CurrentSiteMiddlewareTests(TestCase):
+    @override_settings(SITE_ID=None)
+    def test_process_request(self):
+        """ The method should bypass setting request.site for exempted paths. """
+        path = '/test/'
+        request = RequestFactory().get(path)
+        middleware = CurrentSiteMiddleware()
+
+        # Rather than mock, we simply check for the expected error that occurs when
+        # the SITE_ID is not set.
+        with self.assertRaises(Site.DoesNotExist):
+            middleware.process_request(request)
+
+        with override_settings(CURRENT_SITE_MIDDLEWARE_EXEMPTED_PATHS=[path]):
+            middleware.process_request(request)
+            self.assertFalse(hasattr(request, 'site'))

--- a/credentials/apps/core/tests/test_views.py
+++ b/credentials/apps/core/tests/test_views.py
@@ -17,8 +17,11 @@ from credentials.apps.core.tests.mixins import SiteMixin
 User = get_user_model()
 
 
-class HealthTests(SiteMixin, TestCase):
-    """Tests of the health endpoint."""
+class HealthTests(TestCase):
+    """Tests of the health endpoint.
+
+    These tests do not rely on SiteMixin, because this endpoint should be site-agnostic.
+    """
 
     def test_all_services_available(self):
         """Test that the endpoint reports when all services are healthy."""

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -67,10 +67,14 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.contrib.sites.middleware.CurrentSiteMiddleware',
+    'credentials.apps.core.middleware.CurrentSiteMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
     'waffle.middleware.WaffleMiddleware',
+)
+
+CURRENT_SITE_MIDDLEWARE_EXEMPTED_PATHS = (
+    '/health/',
 )
 
 ROOT_URLCONF = 'credentials.urls'


### PR DESCRIPTION
This will allow our load balancers to come online properly without our
needing to modify configuration every time we deploy a new site.

LEARNER-516