### PR TITLE
Use pytest to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,14 +82,14 @@ private.py
 # pyenv
 .python-version
 
+# Visual Studio Code
+.vscode
+
 *.trace
 
+.cache/
+credentials/media/
 credentials/static/bundles/
 docs/_build/
 node_modules/
-credentials/media/
 webpack-stats.json
-
-
-# Visual Studio Code
-.vscode

--- a/Makefile
+++ b/Makefile
@@ -45,14 +45,14 @@ clean_static:
 
 production-requirements:
 	npm install --production
-	pip install -r requirements.txt --exists-action w
+	pip install -r requirements.txt
 
 requirements:
 	npm install
 	pip install -r requirements/local.txt
 
 test: clean
-	coverage run ./manage.py test credentials --settings=credentials.settings.test
+	coverage run -m pytest
 	coverage report
 
 quality:
@@ -74,7 +74,7 @@ static.watch:
 serve:
 	python manage.py runserver 0.0.0.0:8150
 
-validate: test quality
+validate: quality test
 
 migrate:
 	python manage.py migrate

--- a/credentials/settings/test.py
+++ b/credentials/settings/test.py
@@ -5,24 +5,13 @@ from path import Path as path
 from credentials.settings.base import *
 from credentials.settings.utils import get_logger_config
 
-# TEST SETTINGS
+
 INSTALLED_APPS += [
-    'django_nose',
     'credentials.apps.edx_credentials_extensions',
 ]
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = [
-    '--with-ignore-docstrings',
-    '--logging-level=DEBUG',
-]
-# LOGGING
 LOGGING = get_logger_config(debug=False, dev_env=True, local_loglevel='DEBUG')
-# END TEST SETTINGS
 
-
-# IN-MEMORY TEST DATABASE
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -33,15 +22,13 @@ DATABASES = {
         'PORT': '',
     },
 }
-# END IN-MEMORY TEST DATABASE
 
 # Local Directories
-TEST_ROOT = path("test_root")
+TEST_ROOT = path('test_root')
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
-MEDIA_ROOT = TEST_ROOT / "uploads"
-MEDIA_URL = "/static/uploads/"
+MEDIA_ROOT = TEST_ROOT / 'uploads'
+MEDIA_URL = '/static/uploads/'
 
-# AUTHENTICATION
 OAUTH2_PROVIDER_URL = 'https://test-provider/oauth2'
 SOCIAL_AUTH_EDX_OIDC_URL_ROOT = OAUTH2_PROVIDER_URL
 
@@ -50,4 +37,3 @@ JWT_AUTH.update({
     'JWT_ISSUER': OAUTH2_PROVIDER_URL,
     'JWT_AUDIENCE': SOCIAL_AUTH_EDX_OIDC_KEY,
 })
-# END AUTHENTICATION

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = credentials.settings.test
+testpaths = credentials/apps

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,13 +4,13 @@
 bok-choy==0.6.1
 coverage==4.3.4
 ddt==1.1.1
-django-nose==1.4.4
 edx-lint==0.5.2
 factory-boy==2.8.1
 httpretty==0.8.14
 isort==4.2.5
 mock==2.0.0
-nose-ignore-docstring==0.2
 pep8==1.7.0
+pytest==3.0.7
+pytest-django==3.1.2
 responses==0.5.1
 testfixtures==4.13.4


### PR DESCRIPTION
Having been in maintenance mode for the past several years, nose is effectively dead. edX and the Python community at large are moving towards pytest. pytest is actively developed and provides several benefits over nose, including detailed introspection of failing assert statements (no need to use unittest's assert methods), a rich plugin ecosystem, and modular fixtures (which may help move us away from relying on migrations for populating initial test data).