### PR TITLE
Revert "Added django-cors-headers"

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -44,7 +44,6 @@ THIRD_PARTY_APPS = [
     'waffle',
     'storages',
     'webpack_loader',
-    'corsheaders',
     # TODO Set in EXTRA_APPS via configuration
     'edx_credentials_themes',
 ]
@@ -61,7 +60,6 @@ INSTALLED_APPS += THIRD_PARTY_APPS
 INSTALLED_APPS += PROJECT_APPS
 
 MIDDLEWARE_CLASSES = (
-    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,4 @@
 django==1.9.13
-django-cors-headers==2.0.2
 django-extensions==1.7.8
 django-filter==1.0.1
 django-rest-swagger[reST]==0.3.10


### PR DESCRIPTION
We don't need this app since nginx handles CORS headers for us.