### PR TITLE
Permanently enabled API site filtering

### DIFF
--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -5,10 +5,8 @@ from django.contrib.auth.models import Permission
 from django.core.urlresolvers import reverse
 from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APIRequestFactory, APITestCase
-from waffle.models import Switch
 
 from credentials.apps.api.v2.serializers import UserCredentialAttributeSerializer, UserCredentialSerializer
-from credentials.apps.api.v2.views import DISABLE_API_SITE_FILTERING_SWITCH_NAME
 from credentials.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials.models import UserCredential
@@ -30,7 +28,6 @@ class CredentialViewSetTests(SiteMixin, APITestCase):
     def setUp(self):
         super(CredentialViewSetTests, self).setUp()
         self.user = UserFactory()
-        Switch.objects.update_or_create(name=DISABLE_API_SITE_FILTERING_SWITCH_NAME, defaults={'active': False})
 
     def serialize_user_credential(self, user_credential, many=False):
         """ Serialize the given UserCredential object(s). """
@@ -298,8 +295,3 @@ class CredentialViewSetTests(SiteMixin, APITestCase):
         response = self.client.get(self.list_path)
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0], self.serialize_user_credential(credential))
-
-        # Verify switch *disabling* site filtering disables site filtering
-        Switch.objects.update_or_create(name=DISABLE_API_SITE_FILTERING_SWITCH_NAME, defaults={'active': True})
-        response = self.client.get(self.list_path)
-        self.assertEqual(response.data['count'], 2)

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -1,6 +1,5 @@
 import logging
 
-import waffle
 from django.db.models import Q
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -11,7 +10,6 @@ from credentials.apps.api.v2.serializers import UserCredentialCreationSerializer
 from credentials.apps.credentials.models import UserCredential
 
 log = logging.getLogger(__name__)
-DISABLE_API_SITE_FILTERING_SWITCH_NAME = 'disable_api_site_filtering'
 
 
 class CredentialViewSet(viewsets.ModelViewSet):
@@ -23,13 +21,10 @@ class CredentialViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         queryset = UserCredential.objects.all()
 
-        # NOTE (CCB): We are temporarily disabling multi-tenancy for the API endpoint since the LMS
-        # does not yet support multiple URLs for this service.
-        if not waffle.switch_is_active(DISABLE_API_SITE_FILTERING_SWITCH_NAME):
-            # We have to filter on the explicit credential models
-            # because we cannot set a GenericRelation field on the Site model.
-            site = self.request.site
-            queryset = queryset.filter(Q(program_credentials__site=site) | Q(course_credentials__site=site))
+        # We have to filter on the explicit credential models
+        # because we cannot set a GenericRelation field on the Site model.
+        site = self.request.site
+        queryset = queryset.filter(Q(program_credentials__site=site) | Q(course_credentials__site=site))
 
         return queryset
 


### PR DESCRIPTION
The switch supporting the disabling of site filtering has been removed. This service is now fully multi-tenant.

LEARNER-1102