### PR TITLE
Printing Test Durations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ quality: ## Run linters
 	$(NODE_BIN)/gulp lint
 
 tests: ## Run tests and generate coverage report
-	coverage run -m pytest
+	coverage run -m pytest --durations=25
 	coverage report
 	$(NODE_BIN)/gulp test
 


### PR DESCRIPTION
The durations of the 25 slowest tests will now be printed. This should aid identifying long-running tests.