### PR TITLE
Fix API docs

### DIFF
--- a/credentials/apps/api/tests/test_views.py
+++ b/credentials/apps/api/tests/test_views.py
@@ -1,4 +1,5 @@
 import ddt
+import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.test import RequestFactory, TestCase
@@ -6,6 +7,30 @@ from django.urls import reverse
 
 from credentials.apps.api.views import api_docs_permission_denied_handler
 from credentials.apps.core.tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+class TestApiDocs:
+    """
+    Regression tests introduced following LEARNER-1590.
+    """
+    path = reverse('api_docs')
+
+    def test_api_docs(self, admin_client):
+        """
+        Verify that the API docs are available to authenticated clients.
+        """
+        response = admin_client.get(self.path)
+
+        assert response.status_code == 200
+
+    def test_api_docs_redirect(self, client):
+        """
+        Verify that unauthenticated clients are redirected.
+        """
+        response = client.get(self.path)
+
+        assert response.status_code == 302
 
 
 @ddt.ddt

--- a/credentials/apps/api/views.py
+++ b/credentials/apps/api/views.py
@@ -2,6 +2,38 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+from rest_framework.permissions import AllowAny
+from rest_framework.renderers import CoreJSONRenderer
+from rest_framework.response import Response
+from rest_framework.schemas import SchemaGenerator
+from rest_framework.views import APIView
+from rest_framework_swagger.renderers import OpenAPIRenderer, SwaggerUIRenderer
+
+
+class SwaggerSchemaView(APIView):
+    permission_classes = [AllowAny]
+    renderer_classes = [
+        CoreJSONRenderer,
+        OpenAPIRenderer,
+        SwaggerUIRenderer,
+    ]
+
+    def get(self, request):
+        generator = SchemaGenerator(
+            title='Credentials API',
+            url='/api/v2',
+            urlconf='credentials.apps.api.v2.urls'
+        )
+        schema = generator.get_schema(request=request)
+
+        if not schema:
+            # get_schema() uses the same permissions check as the API endpoints.
+            # If we don't get a schema document back, it means the user is not
+            # authenticated or doesn't have permission to access the API.
+            # api_docs_permission_denied_handler() handles both of these cases.
+            return api_docs_permission_denied_handler(request)
+
+        return Response(schema)
 
 
 def api_docs_permission_denied_handler(request):

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -254,10 +254,7 @@ REST_FRAMEWORK = {
 }
 
 SWAGGER_SETTINGS = {
-    'api_version': 'v2',
-    'doc_expansion': 'list',
-    'is_authenticated': True,
-    'permission_denied_handler': 'credentials.apps.api.views.api_docs_permission_denied_handler'
+    'DOC_EXPANSION': 'list',
 }
 
 

--- a/credentials/static/css/edx-swagger.css
+++ b/credentials/static/css/edx-swagger.css
@@ -1,18 +1,3 @@
-body {
-    margin: 0;
-}
-
-#header {
-    background-color: #fcfcfc;
-    border-bottom: 4px solid #0079bc;
-    color: #999999;
-}
-
-#django-rest-swagger {
-    background-color: white;
-    color: #999999;
-}
-
-#django-rest-swagger a {
-    color: inherit;
+.footer {
+    display: none;
 }

--- a/credentials/templates/rest_framework_swagger/index.html
+++ b/credentials/templates/rest_framework_swagger/index.html
@@ -2,17 +2,9 @@
 
 {% load staticfiles %}
 
-{% block title %}Open edX Credentials API{% endblock %}
-
-{% block style %}
-  {{ block.super }}
-  <link href='{% static "css/edx-swagger.css" %}' media='screen' rel='stylesheet' type='text/css'/>
+{% block extra_styles %}
+<link href='{% static "css/edx-swagger.css" %}' media='screen' rel='stylesheet' type='text/css'/>
 {% endblock %}
 
-
-{% block branding %}
-  <span id="api-name">Open edX Credentials API</span>
-{% endblock %}
-
-{% block api_selector %}
+{% block header %}
 {% endblock %}

--- a/credentials/urls.py
+++ b/credentials/urls.py
@@ -23,7 +23,9 @@ from django.contrib import admin
 from django.views.defaults import page_not_found
 from django.views.i18n import javascript_catalog
 
+from credentials.apps.api.views import SwaggerSchemaView
 from credentials.apps.core import views as core_views
+
 
 admin.autodiscover()
 
@@ -31,7 +33,7 @@ urlpatterns = auth_urlpatterns + [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/', include('credentials.apps.api.urls', namespace='api')),
     url(r'^api-auth/', include(auth_urlpatterns, namespace='rest_framework')),
-    url(r'^api-docs/', include('rest_framework_swagger.urls')),
+    url(r'^api-docs/', SwaggerSchemaView.as_view(), name='api_docs'),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^credentials/', include('credentials.apps.credentials.urls', namespace='credentials')),
     url(r'^health/$', core_views.health, name='health'),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 django==1.11.3
 django-extensions==1.7.9
 django-filter==1.0.4
-django-rest-swagger[reST]==0.3.10
+django-rest-swagger==2.0.7
 django-storages==1.5.2
 django-waffle==0.12.0
 django-webpack-loader==0.5.0


### PR DESCRIPTION
The API docs were broken by the Django 1.11 upgrade. This change includes an upgrade to the most recent version of django-rest-swagger that supports DRF 3.4. Newer versions of django-rest-swagger require DRF 3.5.

LEARNER-1590

@edx/learner FYI