### PR TITLE
Upgrade to DRF 3.5.4

### DIFF
--- a/credentials/apps/api/views.py
+++ b/credentials/apps/api/views.py
@@ -18,12 +18,10 @@ class SwaggerSchemaView(APIView):
         SwaggerUIRenderer,
     ]
 
+    exclude_from_schema = True
+
     def get(self, request):
-        generator = SchemaGenerator(
-            title='Credentials API',
-            url='/api/v2',
-            urlconf='credentials.apps.api.v2.urls'
-        )
+        generator = SchemaGenerator(title='Credentials API')
         schema = generator.get_schema(request=request)
 
         if not schema:

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -246,7 +246,7 @@ REST_FRAMEWORK = {
         'credentials.apps.api.authentication.BearerAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
-    'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
+    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.DjangoModelPermissions',),
     'PAGE_SIZE': 20,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,11 +1,11 @@
 django==1.11.3
 django-extensions==1.7.9
 django-filter==1.0.4
-django-rest-swagger==2.0.7
+django-rest-swagger==2.1.2
 django-storages==1.5.2
 django-waffle==0.12.0
 django-webpack-loader==0.5.0
-djangorestframework==3.4.7
+djangorestframework==3.5.4
 djangorestframework-jwt==1.10.0
 edx-auth-backends==1.1.2
 edx-django-release-util==0.3.1


### PR DESCRIPTION
3.5.4 features improved schema generation, including the ability to exclude views from generated schemas. 3.5.4 deprecates DjangoFilterBackend in favor of the implementation provided by the django-filter package.

LEARNER-1590

@edx/learner FYI.