### PR TITLE
Include django_filters in INSTALLED_APPS

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -43,6 +43,7 @@ THIRD_PARTY_APPS = [
     'waffle',
     'storages',
     'webpack_loader',
+    'django_filters',
     'django_sites_extensions',
     # TODO Set in EXTRA_APPS via configuration
     'edx_credentials_themes',


### PR DESCRIPTION
This fixes an issue which prevents the browseable API from rendering. For more details, see https://github.com/carltongibson/django-filter/issues/562/#issuecomment-291035404.

LEARNER-1590

@edx/learner FYI.