### PR TITLE
Fix wrap behavior of accomplishment stamps on base program template

### DIFF
--- a/credentials/apps/credentials_theme_openedx/static/sass/_layouts-rendering.scss
+++ b/credentials/apps/credentials_theme_openedx/static/sass/_layouts-rendering.scss
@@ -161,8 +161,6 @@
 }
 
 .accomplishment-stamps {
-  @extend %list-unstyled;
-
   .accomplishment-stamp-platform {
     margin-bottom: 15px;
 
@@ -181,32 +179,43 @@
     }
   }
 
-  .accomplishment-stamp-date {
-    margin-bottom: 10px;
-
+  .wrapper-inner-accomplishment-stamps {
     @include susy-breakpoint($bp-screen-lg, $susy) {
       display: inline-block;
       vertical-align: middle;
-      @include margin-right(25px);
+      width: calc(100% - 160px);
     }
-  }
 
-  .accomplishment-stamp-validity {
-    margin-bottom: 10px;
+    .accomplishment-stamp-date {
+      margin-bottom: 10px;
 
-    @include susy-breakpoint($bp-screen-lg, $susy) {
-      display: inline-block;
-      vertical-align: middle;
-      @include margin-right(25px);
+      @include susy-breakpoint($bp-screen-lg, $susy) {
+        display: inline-block;
+        vertical-align: top;
+        max-width: 30%;
+        @include margin-right(5%);
+      }
     }
-  }
 
-  .accomplishment-stamp-effort {
-    margin-bottom: 10px;
+    .accomplishment-stamp-validity {
+      margin-bottom: 10px;
 
-    @include susy-breakpoint($bp-screen-lg, $susy) {
-      display: inline-block;
-      vertical-align: middle;
+      @include susy-breakpoint($bp-screen-lg, $susy) {
+        display: inline-block;
+        vertical-align: top;
+        max-width: 30%;
+        @include margin-right(5%);
+      }
+    }
+
+    .accomplishment-stamp-effort {
+      margin-bottom: 10px;
+
+      @include susy-breakpoint($bp-screen-lg, $susy) {
+        display: inline-block;
+        vertical-align: top;
+        max-width: 30%;
+      }
     }
   }
 }

--- a/credentials/apps/credentials_theme_openedx/static/sass/_print-rendering.scss
+++ b/credentials/apps/credentials_theme_openedx/static/sass/_print-rendering.scss
@@ -84,7 +84,7 @@
 
     .accomplishment-stamp-platform {
       display: inline-block;
-      vertical-align: top;
+      vertical-align: middle;
       @include margin-right(25px);
       margin-bottom: 0;
       padding-top: 0;
@@ -96,21 +96,30 @@
       }
     }
 
-    .accomplishment-stamp-date {
+    .wrapper-inner-accomplishment-stamps {
       display: inline-block;
-      vertical-align: top;
-      @include margin-right(25px);
-    }
+      vertical-align: middle;
+      width: calc(100% - 105px);
 
-    .accomplishment-stamp-validity {
-      display: inline-block;
-      vertical-align: top;
-      @include margin-right(25px);
-    }
+      .accomplishment-stamp-date {
+        display: inline-block;
+        vertical-align: top;
+        max-width: 30%;
+        @include margin-right(5%);
+      }
 
-    .accomplishment-stamp-effort {
-      display: inline-block;
-      vertical-align: top;
+      .accomplishment-stamp-validity {
+        display: inline-block;
+        vertical-align: top;
+        max-width: 30%;
+        @include margin-right(5%);
+      }
+
+      .accomplishment-stamp-effort {
+        display: inline-block;
+        vertical-align: top;
+        max-width: 30%;
+      }
     }
   }
 }

--- a/credentials/templates/credentials/programs/base.html
+++ b/credentials/templates/credentials/programs/base.html
@@ -91,31 +91,33 @@
         </div>
       </div>
       <div class="wrapper-accomplishment-stamps">
-        <ul class="accomplishment-stamps copy-list">
-          <li class="accomplishment-stamp-platform">
+        <div class="accomplishment-stamps">
+          <div class="accomplishment-stamp-platform">
             {% block platform_logo %}
             {% endblock %}
-          </li>
-          <li class="accomplishment-stamp-date">
-            <span class="title">{% block accomplishment_stamp_title %}{% endblock %}</span>
-            <span class="copy-micro emphasized">{% trans "Issued" as tmsg %}{{ tmsg | htmlescape }} {{ user_credential.modified|date:"F Y" }}</span>
-          </li>
-          <li class="accomplishment-stamp-validity">
-            <span class="title">{% trans "Valid Certificate ID" as tmsg %}{{ tmsg | htmlescape }}</span>
-            <span class="emphasized">{{ user_credential.uuid.hex }}</span>
-          </li>
+          </div>
+          <div class="wrapper-inner-accomplishment-stamps">
+            <div class="accomplishment-stamp-date">
+              <span class="title">{% block accomplishment_stamp_title %}{% endblock %}</span>
+              <span class="copy-micro emphasized">{% trans "Issued" as tmsg %}{{ tmsg | htmlescape }} {{ user_credential.modified|date:"F Y" }}</span>
+            </div>
+            <div class="accomplishment-stamp-validity">
+              <span class="title">{% trans "Valid Certificate ID" as tmsg %}{{ tmsg | htmlescape }}</span>
+              <span class="emphasized">{{ user_credential.uuid.hex }}</span>
+            </div>
 
-          {% if hours_of_effort %}
-            <li class="accomplishment-stamp-effort">
-              <span class="title">{% trans "Effort" as tmsg %}{{ tmsg | htmlescape }}</span>
-              <span class="emphasized">
-                {% filter htmlescape %}
-                  {% blocktrans count num_hours=hours_of_effort %}{{num_hours}} hour{% plural %}{{num_hours}} hours{% endblocktrans %}
-                {% endfilter %}
-              </span>
-            </li>
-          {% endif %}
-        </ul>
+            {% if hours_of_effort %}
+              <div class="accomplishment-stamp-effort">
+                <span class="title">{% trans "Effort" as tmsg %}{{ tmsg | htmlescape }}</span>
+                <span class="emphasized">
+                  {% filter htmlescape %}
+                    {% blocktrans count num_hours=hours_of_effort %}{{num_hours}} hour{% plural %}{{num_hours}} hours{% endblocktrans %}
+                  {% endfilter %}
+                </span>
+              </div>
+            {% endif %}
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
There's an issue with the base program template where the accomplishment stamps get pushed to a new line if the text in the stamps is too long. This isn't an issue when the templates are viewed in English, but it may become one if/when we translate this text.

https://openedx.atlassian.net/browse/LEARNER-3012