### PR TITLE
LEARNER-3070: adds in dark styling for a11y issues

### DIFF
--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -178,6 +178,7 @@ class ExampleCredential(SocialMediaMixin, ThemeViewMixin, TemplateView):
             },
             'page_title': program_details.type,
             'program_name': program_details.title,
+            'render_language': settings.LANGUAGE_CODE,
         })
 
         return context

--- a/credentials/apps/credentials_theme_openedx/static/sass/_components-rendering.scss
+++ b/credentials/apps/credentials_theme_openedx/static/sass/_components-rendering.scss
@@ -180,7 +180,7 @@
 
   .title {
     @extend %hd-8;
-    color: palette(grayscale, base);
+    color: palette(grayscale, dark);
     display: block;
     margin-bottom: 0;
   }


### PR DESCRIPTION
### Description

[LEARNER-3070](https://openedx.atlassian.net/browse/LEARNER-3070)

Adds in a11y fixes for templates (contrast ratio fix and empty HTML lang attribute for example certs)

FYI: @edx/learner-heart 