### PR TITLE
Remove verbose output for travis step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_install:
   - sudo apt-get -y install -o Dpkg::Options::="--force-confnew" docker-ce
   - docker --version
 
-  # Build the image
-  - docker-compose build
+  # Build the image.
+  - docker-compose build > /dev/null
 
   # Ensure we have a place to store coverage output
   - mkdir -p coverage


### PR DESCRIPTION
Tests might be failing because of the verbose deprecation error output when compiling assets. This PR pipes the output to `/dev/null`. If `make static` fails, the build will still fail.