### PR TITLE
ARCH-93 Use django-rest-swagger to generate API documentation.

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -49,6 +49,7 @@ THIRD_PARTY_APPS = [
     'django_sites_extensions',
     # TODO Set in EXTRA_APPS via configuration
     'edx_credentials_themes',
+    'rest_framework_swagger',
 ]
 
 PROJECT_APPS = [

--- a/credentials/tests/test_urls.py
+++ b/credentials/tests/test_urls.py
@@ -7,7 +7,7 @@ def test_api_docs(client):
     """
     Verify that the API docs render.
     """
-    path = reverse('api-docs:docs-index')
+    path = reverse('api_docs')
     response = client.get(path)
 
     assert response.status_code == 200

--- a/credentials/urls.py
+++ b/credentials/urls.py
@@ -22,7 +22,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 from django.views.defaults import page_not_found
-from rest_framework.documentation import include_docs_urls
+from rest_framework_swagger.views import get_swagger_view
 
 from credentials.apps.core import views as core_views
 
@@ -35,7 +35,7 @@ urlpatterns = auth_urlpatterns + [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/', include('credentials.apps.api.urls', namespace='api')),
     url(r'^api-auth/', include(auth_urlpatterns, namespace='rest_framework')),
-    url(r'^api-docs/', include_docs_urls(title='Credentials API')),
+    url(r'^api-docs/', get_swagger_view(title='Credentials API'), name='api_docs'),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^credentials/', include('credentials.apps.credentials.urls', namespace='credentials')),
     url(r'^health/$', core_views.health, name='health'),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@ coreapi==2.3.1
 django==1.11.11
 django-extensions==1.7.9
 django-filter==1.0.4
+django-rest-swagger==2.2.0
 django-statici18n==1.7.0
 django-storages==1.5.2
 django-waffle==0.12.0


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ARCH-93

**Sandbox:** https://credentials-swagger.sandbox.edx.org/api-docs/