### PR TITLE
Set HTML lang tag for records pages

### DIFF
--- a/credentials/apps/credentials/tests/test_views.py
+++ b/credentials/apps/credentials/tests/test_views.py
@@ -167,7 +167,7 @@ class RenderCredentialViewTests(SiteMixin, TestCase):
 
     @ddt.data(
         (True, 'lang="es_419"'),
-        (False, 'lang="en-us"')
+        (False, 'lang="en"')
     )
     @ddt.unpack
     @responses.activate

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -36,6 +36,7 @@ class RecordsView(LoginRequiredMixin, TemplateView, ThemeViewMixin):
                 'header': self.select_theme_template(['_header.html']),
             },
             'programs': json.dumps(self._get_programs(), sort_keys=True),
+            'render_language': self.request.LANGUAGE_CODE,
         })
         return context
 

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -100,7 +100,7 @@ DATABASES = {
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en'
 
 TIME_ZONE = 'UTC'
 

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -10,7 +10,7 @@ LOGGING = get_logger_config(debug=True, dev_env=True, local_loglevel='DEBUG')
 del LOGGING['handlers']['local']
 
 SECRET_KEY = os.environ.get('SECRET_KEY', 'change-me')
-LANGUAGE_CODE = os.environ.get('LANGUAGE_CODE', 'en-us')
+LANGUAGE_CODE = os.environ.get('LANGUAGE_CODE', 'en')
 
 CACHES = {
     'default': {

--- a/credentials/templates/base.html
+++ b/credentials/templates/base.html
@@ -18,7 +18,7 @@
       {% render_bundle 'base.style-ltr' 'css' %}
     {% endif %}
 
-    <script src="{% statici18n LANGUAGE_CODE %}"></script>
+    <script src="{% statici18n render_language %}"></script>
 
     {# Hook for credentials themes to overwrite. #}
     {% block theme_meta %}


### PR DESCRIPTION
Make sure that the <html lang=""> tag is set for new Student Records work.

I also cleaned up a few instances of using en-us as the fallback language code. Our locale generated for English is 'en' not 'en-us' and in production, we already configure 'en' as the fallback. So devstack should be in sync too.