### PR TITLE
Fix 500s on Spanish certificates

### DIFF
--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -233,7 +233,7 @@ class ProgramCertificate(AbstractCertificate):
     language = models.CharField(
         max_length=8,
         null=True,
-        help_text=u'Language in which certificates for this program will be rendered'
+        help_text=u'Locale in which certificates for this program will be rendered'
     )
 
     def __str__(self):

--- a/credentials/apps/credentials/tests/test_views.py
+++ b/credentials/apps/credentials/tests/test_views.py
@@ -166,7 +166,7 @@ class RenderCredentialViewTests(SiteMixin, TestCase):
             self._render_user_credential(use_proper_logo_url=False)
 
     @ddt.data(
-        (True, 'lang="es_419"'),
+        (True, 'lang="es-419"'),
         (False, 'lang="en"')
     )
     @ddt.unpack

--- a/credentials/apps/credentials/utils.py
+++ b/credentials/apps/credentials/utils.py
@@ -1,6 +1,13 @@
 from itertools import groupby
 
 
+def to_language(locale):
+    if locale is None:
+        return None
+    # Convert to bytes to get ascii-lowercasing, to avoid the Turkish I problem.
+    return locale.replace('_', '-').encode().lower().decode()
+
+
 def validate_duplicate_attributes(attributes):
     """
     Validate the attributes data

--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -13,6 +13,7 @@ from django.views.generic import TemplateView
 from credentials.apps.core.views import ThemeViewMixin
 from credentials.apps.credentials.exceptions import MissingCertificateLogoError
 from credentials.apps.credentials.models import OrganizationDetails, ProgramCertificate, ProgramDetails, UserCredential
+from credentials.apps.credentials.utils import to_language
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +68,7 @@ class RenderCredential(SocialMediaMixin, ThemeViewMixin, TemplateView):
                                                   format(program_uuid=program_details.uuid))
 
         user_data = user_credential.credential.site.siteconfiguration.get_user_api_data(user_credential.username)
-        content_language = user_credential.credential.language
+        content_language = to_language(user_credential.credential.language)
 
         context.update({
             'user_credential': user_credential,


### PR DESCRIPTION
Don't pass our templates a locale, instead make sure it's a language code (es-419 instead of es_419).

Annoyingly, django doesn't expose their own to_language implementation, only their to_locale implementation. They expect you to get language codes from their translation objects. But that's not what we have here. So I just made a function, it's simple enough.

I'll come back with a second PR to add a new Spanish example cert to help avoid testing gaps like this in the future.

https://openedx.atlassian.net/browse/LEARNER-5347