### PR TITLE
Fix records links

### DIFF
--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -19,12 +19,12 @@ class RecordsView(LoginRequiredMixin, TemplateView, ThemeViewMixin):
             {
                 'name': 'Dog Mind Reading',
                 'partner': 'DOGx',
-                'uuid': 'XXXXXXXX',
+                'uuid': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             },
             {
                 "name": "MIT's Simple XSS <script>alert(\"Attack\")</script>",
                 'partner': 'MITx',
-                'uuid': 'YYYYYYYY',
+                'uuid': 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
             },
         ]
 


### PR DESCRIPTION
The fake links from My Records to individual records pages was not working because they weren't valid uuids. Fixed that. You still don't get real content, but at least the flow is correct now.