### PR TITLE
Create course certs when asked

### DIFF
--- a/credentials/apps/api/accreditors.py
+++ b/credentials/apps/api/accreditors.py
@@ -2,7 +2,8 @@
 import logging
 
 from credentials.apps.api import exceptions
-from credentials.apps.credentials.issuers import ProgramCertificateIssuer
+from credentials.apps.credentials.constants import UserCredentialStatus
+from credentials.apps.credentials.issuers import CourseCertificateIssuer, ProgramCertificateIssuer
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ class Accreditor(object):
     class for generating credential.
     """
     def __init__(self, issuers=None):
-        self.issuers = issuers or [ProgramCertificateIssuer()]
+        self.issuers = issuers or [CourseCertificateIssuer(), ProgramCertificateIssuer()]
         self._create_credential_type_issuer_map()
 
     def _create_credential_type_issuer_map(self):
@@ -29,12 +30,13 @@ class Accreditor(object):
             else:
                 self.credential_type_issuer_map[credential_type] = issuer
 
-    def issue_credential(self, credential, username, attributes=None):
+    def issue_credential(self, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
         """Issues a credential.
 
         Arguments:
             credential (AbstractCredential): Type of credential to issue.
-            username (string): Username of the recipient.
+            username (str): Username of the recipient.
+            status (str): Status of credential.
             attributes (List[dict]): attributes list containing dictionaries of attributes
 
         Returns:
@@ -52,4 +54,4 @@ class Accreditor(object):
                 )
             )
 
-        return credential_issuer.issue_credential(credential, username, attributes)
+        return credential_issuer.issue_credential(credential, username, status, attributes)

--- a/credentials/apps/api/docs/decisions/0001-post-as-update-or-create.md
+++ b/credentials/apps/api/docs/decisions/0001-post-as-update-or-create.md
@@ -1,0 +1,22 @@
+# Credentials POST as update-or-create
+
+## Status
+
+Accepted
+
+## Context
+
+The LMS wants to notify the Credential service whenever a user credential is created
+or changed (status changes, different attributes, etc).
+
+But the LMS doesn't know what the resource ID is for a given credential (doesn't know
+what the uuid is) in order to do a traditional PUT for that resource. It could find it
+out if it did a round-trip first. But that's a pain and inefficient.
+
+Instead, we want a way to just tell Credentials, "here is a bundle of data, just make
+it true."
+
+## Decision
+
+Despite it being slightly non-RESTful, we'll treat a POST on the main credentials endpoint
+as an update-or-create instead of the normal just-create.

--- a/credentials/apps/api/tests/test_accreditors.py
+++ b/credentials/apps/api/tests/test_accreditors.py
@@ -8,8 +8,8 @@ from testfixtures import LogCapture
 
 from credentials.apps.api.accreditors import Accreditor
 from credentials.apps.api.exceptions import UnsupportedCredentialTypeError
-from credentials.apps.credentials.issuers import ProgramCertificateIssuer
-from credentials.apps.credentials.models import ProgramCertificate
+from credentials.apps.credentials.issuers import CourseCertificateIssuer, ProgramCertificateIssuer
+from credentials.apps.credentials.models import CourseCertificate, ProgramCertificate
 from credentials.apps.credentials.tests.factories import CourseCertificateFactory, ProgramCertificateFactory
 
 LOGGER_NAME = 'credentials.apps.api.accreditors'
@@ -17,11 +17,11 @@ LOGGER_NAME = 'credentials.apps.api.accreditors'
 
 class AccreditorTests(TestCase):
     attributes = [{'name': 'whitelist_reason', 'value': 'Reason for whitelisting.'}]
+    course_credential = CourseCertificate
     program_credential = ProgramCertificate
 
     def setUp(self):
         super().setUp()
-        self.accreditor = Accreditor()
         self.program_cert = ProgramCertificateFactory()
 
     def test_create_credential_type_issuer_map(self):
@@ -35,15 +35,17 @@ class AccreditorTests(TestCase):
 
     def test_issue_credential_with_invalid_type(self):
         """ Verify the method raises an error for attempts to issue an unsupported credential type. """
+        accreditor = Accreditor(issuers=[ProgramCertificateIssuer()])
         course_cert = CourseCertificateFactory()
         with self.assertRaises(UnsupportedCredentialTypeError):
-            self.accreditor.issue_credential(course_cert, 'tester', self.attributes)
+            accreditor.issue_credential(course_cert, 'tester', attributes=self.attributes)
 
     def test_issue_credential(self):
         """ Verify the method calls the Issuer's issue_credential method. """
+        accreditor = Accreditor(issuers=[ProgramCertificateIssuer()])
         with patch.object(ProgramCertificateIssuer, 'issue_credential') as mock_method:
-            self.accreditor.issue_credential(self.program_cert, 'tester', self.attributes)
-            mock_method.assert_called_with(self.program_cert, 'tester', self.attributes)
+            accreditor.issue_credential(self.program_cert, 'tester', attributes=self.attributes)
+            mock_method.assert_called_with(self.program_cert, 'tester', 'awarded', self.attributes)
 
     def test_constructor_with_multiple_issuers_for_same_credential_type(self):
         """ Verify the Accreditor supports a single Issuer per credential type.
@@ -59,3 +61,13 @@ class AccreditorTests(TestCase):
             l.check((LOGGER_NAME, 'WARNING', msg))
         expected = {self.program_credential: accreditor.issuers[0]}
         self.assertEqual(accreditor.credential_type_issuer_map, expected)
+
+    def test_constructor_with_multiple_issuers(self):
+        """ Verify the Accreditor supports multiple Issuers """
+        accreditor = Accreditor(issuers=[CourseCertificateIssuer(), ProgramCertificateIssuer()])
+
+        expected = {
+            self.course_credential: accreditor.issuers[0],
+            self.program_credential: accreditor.issuers[1],
+        }
+        self.assertDictEqual(accreditor.credential_type_issuer_map, expected)

--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from uuid import uuid4
 
 import ddt
@@ -10,24 +11,36 @@ from rest_framework.test import APIRequestFactory
 from credentials.apps.api.v2.serializers import (
     CredentialField, UserCredentialAttributeSerializer, UserCredentialCreationSerializer, UserCredentialSerializer
 )
+from credentials.apps.core.tests.mixins import SiteMixin
+from credentials.apps.credentials.models import CourseCertificate
 from credentials.apps.credentials.tests.factories import (
     CourseCertificateFactory, ProgramCertificateFactory, UserCredentialAttributeFactory, UserCredentialFactory
 )
 
 
 @ddt.ddt
-class CredentialFieldTests(TestCase):
+class CredentialFieldTests(SiteMixin, TestCase):
     def setUp(self):
         super(CredentialFieldTests, self).setUp()
-        self.program_certificate = ProgramCertificateFactory()
-        self.course_certificate = CourseCertificateFactory()
+        self.program_certificate = ProgramCertificateFactory(site=self.site)
+        self.course_certificate = CourseCertificateFactory(site=self.site, certificate_type='verified')
         self.field_instance = CredentialField()
+        self.field_instance.context['request'] = namedtuple('HttpRequest', ['site'])(self.site)
 
     def assert_program_uuid_validation_error_raised(self, program_uuid):
         try:
             self.field_instance.to_internal_value({'program_uuid': program_uuid})
         except ValidationError as ex:
             expected = {'program_uuid': 'No active ProgramCertificate exists for program [{}]'.format(program_uuid)}
+            self.assertEqual(ex.detail, expected)
+
+    def assert_course_run_key_validation_error_raised(self, course_run_key):
+        try:
+            self.field_instance.to_internal_value({'course_run_key': course_run_key, 'mode': 'verified'})
+        except ValidationError as ex:
+            expected = {
+                'course_run_key': 'No active CourseCertificate exists for course run [{}]'.format(course_run_key)
+            }
             self.assertEqual(ex.detail, expected)
 
     def test_to_internal_value_with_empty_program_uuid(self):
@@ -42,6 +55,11 @@ class CredentialFieldTests(TestCase):
         """
         self.assert_program_uuid_validation_error_raised(uuid4())
 
+    def test_to_internal_value_with_invalid_site(self, ):
+        """ Verify the method raises a ValidationError if the passed program UUID belongs to a different site. """
+        certificate = ProgramCertificateFactory()  # without setting site=self.site
+        self.assert_program_uuid_validation_error_raised(certificate.program_uuid)
+
     def test_to_internal_value_with_inactive_program_certificate(self, ):
         """ Verify the method raises a ValidationError if the ProgramCertificate is NOT active. """
         self.program_certificate.is_active = False
@@ -54,6 +72,37 @@ class CredentialFieldTests(TestCase):
         self.assertEqual(
             self.field_instance.to_internal_value({'program_uuid': self.program_certificate.program_uuid}),
             self.program_certificate
+        )
+
+    def test_to_internal_value_with_created_course_credential(self):
+        """ Verify the method creates a course credential if needed. """
+        credential = self.field_instance.to_internal_value({'course_run_key': 'create-me', 'mode': 'verified'})
+        self.assertEqual(credential, CourseCertificate.objects.get(course_id='create-me'))
+
+    def test_to_internal_value_with_created_course_credential_read_only(self):
+        """ Verify the method refuses to create a course credential when read-only. """
+        self.field_instance.read_only = True
+        self.assert_course_run_key_validation_error_raised('create-me')
+
+    def test_to_internal_value_with_created_course_credential_no_type_change(self):
+        """ Verify the method won't update cert information when creating a course credential. """
+        credential = self.field_instance.to_internal_value({'course_run_key': self.course_certificate.course_id,
+                                                            'mode': 'honor'})
+        credential.refresh_from_db()  # just in case
+        self.assertEqual(credential.certificate_type, 'verified')
+
+    def test_to_internal_value_with_inactive_course_credential(self):
+        """ Verify the method raises a ValidationError if the CourseCertificate is NOT active. """
+        self.course_certificate.is_active = False
+        self.course_certificate.save()
+        self.assert_course_run_key_validation_error_raised(self.course_certificate.course_id)
+
+    def test_to_internal_value_with_valid_course_credential(self):
+        """ Verify the method serializes the course credential details to a dict. """
+        self.assertEqual(
+            self.field_instance.to_internal_value({'course_run_key': self.course_certificate.course_id,
+                                                   'mode': 'verified'}),
+            self.course_certificate
         )
 
     def test_to_representation_data_with_program(self):
@@ -71,7 +120,7 @@ class CredentialFieldTests(TestCase):
 
         expected = {
             'type': 'course-run',
-            'course_run_id': self.course_certificate.course_id,
+            'course_run_key': self.course_certificate.course_id,
             'mode': self.course_certificate.certificate_type,
         }
         self.assertEqual(self.field_instance.to_representation(self.course_certificate), expected)
@@ -163,7 +212,7 @@ class UserCredentialSerializerTests(TestCase):
             'uuid': str(user_credential.uuid),
             'credential': {
                 'type': 'course-run',
-                'course_run_id': course_certificate.course_id,
+                'course_run_key': course_certificate.course_id,
                 'mode': course_certificate.certificate_type,
             },
             'download_url': user_credential.download_url,

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -29,10 +29,10 @@ class CredentialViewSet(viewsets.ModelViewSet):
         return queryset
 
     def create(self, request, *args, **kwargs):
-        """ Create a new credential.
+        """ Create or update a credential.
 
         This endpoint does not work in the swagger docs because it is not configured to accept dicts.
-        Use OPTIONS api/v<version>/credentials/ to understand the schema.
+        Use OPTIONS api/vX/credentials/ to understand the schema.
         ---
         serializer: UserCredentialCreationSerializer
         omit_parameters:

--- a/credentials/apps/credentials/tests/test_issuer.py
+++ b/credentials/apps/credentials/tests/test_issuer.py
@@ -1,65 +1,76 @@
 """
 Tests for Issuer class.
 """
-import ddt
 from django.test import TestCase
 
 from credentials.apps.api.exceptions import DuplicateAttributeError
-from credentials.apps.credentials.issuers import ProgramCertificateIssuer
-from credentials.apps.credentials.models import ProgramCertificate, UserCredentialAttribute
-from credentials.apps.credentials.tests.factories import ProgramCertificateFactory
+from credentials.apps.credentials.issuers import CourseCertificateIssuer, ProgramCertificateIssuer
+from credentials.apps.credentials.models import CourseCertificate, ProgramCertificate, UserCredentialAttribute
+from credentials.apps.credentials.tests.factories import CourseCertificateFactory, ProgramCertificateFactory
 
 LOGGER_NAME = 'credentials.apps.credentials.issuers'
 
 
-@ddt.ddt
-class ProgramCertificateIssuerTests(TestCase):
-    """ Tests for Issuer class and its methods."""
+# pylint: disable=no-member
+class CertificateIssuerBase(object):
+    """ Tests an Issuer class and its methods."""
+    issuer = None
+    cert_factory = None
+    cert_type = None
 
     def setUp(self):
-        super(ProgramCertificateIssuerTests, self).setUp()
-        self.issuer = ProgramCertificateIssuer()
-        self.program_certificate = ProgramCertificateFactory.create()
+        super(CertificateIssuerBase, self).setUp()
+        self.certificate = self.cert_factory.create()
         self.username = 'tester'
-        self.user_program_cred = self.issuer.issue_credential(self.program_certificate, self.username)
+        self.user_cred = self.issuer.issue_credential(self.certificate, self.username)
         self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
 
     def test_issued_credential_type(self):
         """ Verify issued_credential_type returns the correct credential type."""
-        self.assertEqual(self.issuer.issued_credential_type, ProgramCertificate)
+        self.assertEqual(self.issuer.issued_credential_type, self.cert_type)
+
+    def test_issue_existing_credential(self):
+        """ Verify credentials can be updated when re-issued."""
+
+        user_credential = self.issuer.issue_credential(self.certificate, self.username, 'revoked')
+        self.user_cred.refresh_from_db()
+        self._assert_usercredential_fields(self.user_cred, self.certificate, self.username, 'revoked', [])
+        self.assertEqual(user_credential, self.user_cred)
 
     def test_issue_credential_without_attributes(self):
         """ Verify credentials can be issued without attributes."""
 
-        user_credential = self.issuer.issue_credential(self.program_certificate, self.username)
-        self._assert_usercredential_fields(user_credential, self.program_certificate, self.username, [])
+        user_credential = self.issuer.issue_credential(self.certificate, self.username)
+        self._assert_usercredential_fields(user_credential, self.certificate, self.username, 'awarded', [])
 
     def test_issue_credential_with_attributes(self):
         """ Verify credentials can be issued with attributes."""
 
-        user_credential = self.issuer.issue_credential(self.program_certificate, 'testuser2', self.attributes)
-        self._assert_usercredential_fields(user_credential, self.program_certificate, 'testuser2', self.attributes)
+        user_credential = self.issuer.issue_credential(self.certificate, 'testuser2', attributes=self.attributes)
+        self._assert_usercredential_fields(user_credential, self.certificate, 'testuser2', 'awarded', self.attributes)
 
-    def _assert_usercredential_fields(self, user_credential, expected_credential, expected_username, expected_attrs):
+    def _assert_usercredential_fields(self, user_credential, expected_credential, expected_username, expected_status,
+                                      expected_attrs):
         """ Verify the fields on a UserCredential object match expectations. """
         self.assertEqual(user_credential.username, expected_username)
         self.assertEqual(user_credential.credential, expected_credential)
+        self.assertEqual(user_credential.status, expected_status)
         actual_attributes = [{'name': attr.name, 'value': attr.value} for attr in user_credential.attributes.all()]
         self.assertEqual(actual_attributes, expected_attrs)
 
     def test_set_credential_without_attributes(self):
         """ Verify that if no attributes given then None will return."""
         self.assertEqual(
-            self.issuer.set_credential_attributes(self.user_program_cred, None),
+            self.issuer.set_credential_attributes(self.user_cred, None),
             None
         )
 
     def test_set_credential_with_attributes(self):
         """ Verify that it adds the given attributes against user credential."""
 
-        self.issuer.set_credential_attributes(self.user_program_cred, self.attributes)
+        self.issuer.set_credential_attributes(self.user_cred, self.attributes)
         self._assert_usercredential_fields(
-            self.user_program_cred, self.program_certificate, self.user_program_cred.username, self.attributes
+            self.user_cred, self.certificate, self.user_cred.username, 'awarded', self.attributes
         )
 
     def test_set_credential_with_duplicate_attributes_by_util(self):
@@ -70,7 +81,7 @@ class ProgramCertificateIssuerTests(TestCase):
         self.attributes.append({"name": "whitelist_reason", "value": "Reason for whitelisting."})
 
         with self.assertRaises(DuplicateAttributeError):
-            self.issuer.set_credential_attributes(self.user_program_cred, self.attributes)
+            self.issuer.set_credential_attributes(self.user_cred, self.attributes)
 
     def test_existing_credential_with_duplicate_attributes(self):
         """Verify if user credential attributes already exists in db then method will
@@ -82,17 +93,18 @@ class ProgramCertificateIssuerTests(TestCase):
         attribute_db = {"name": "whitelist_reason", "value": "Reason for whitelisting."}
 
         UserCredentialAttribute.objects.create(
-            user_credential=self.user_program_cred,
+            user_credential=self.user_cred,
             name=attribute_db.get("name"),
             value=attribute_db.get("value")
         )
-        self.issuer.set_credential_attributes(self.user_program_cred, self.attributes)
+        self.issuer.set_credential_attributes(self.user_cred, self.attributes)
 
         # first attribute value will be changed to 0.5
         self._assert_usercredential_fields(
-            self.user_program_cred,
-            self.program_certificate,
-            self.user_program_cred.username,
+            self.user_cred,
+            self.certificate,
+            self.user_cred.username,
+            'awarded',
             self.attributes
         )
 
@@ -100,13 +112,27 @@ class ProgramCertificateIssuerTests(TestCase):
         """Verify if user credential attributes already exists in db then in case of empty
         attributes list it will return without changing any data."""
 
-        self.issuer.set_credential_attributes(self.user_program_cred, self.attributes)
+        self.issuer.set_credential_attributes(self.user_cred, self.attributes)
         self._assert_usercredential_fields(
-            self.user_program_cred, self.program_certificate, self.user_program_cred.username, self.attributes
+            self.user_cred, self.certificate, self.user_cred.username, 'awarded', self.attributes
         )
 
         # create same credential without attributes.
-        self.assertIsNone(self.issuer.set_credential_attributes(self.user_program_cred, []))
+        self.assertIsNone(self.issuer.set_credential_attributes(self.user_cred, []))
         self._assert_usercredential_fields(
-            self.user_program_cred, self.program_certificate, self.user_program_cred.username, self.attributes
+            self.user_cred, self.certificate, self.user_cred.username, 'awarded', self.attributes
         )
+
+
+class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
+    """ Tests for program Issuer class and its methods."""
+    issuer = ProgramCertificateIssuer()
+    cert_factory = ProgramCertificateFactory
+    cert_type = ProgramCertificate
+
+
+class CourseCertificateIssuerTests(CertificateIssuerBase, TestCase):
+    """ Tests for course Issuer class and its methods."""
+    issuer = CourseCertificateIssuer()
+    cert_factory = CourseCertificateFactory
+    cert_type = CourseCertificate

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -52,3 +52,9 @@ SOCIAL_AUTH_EDX_OIDC_PUBLIC_URL_ROOT = os.environ.get('SOCIAL_AUTH_EDX_OIDC_PUBL
 SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = os.environ.get('SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY',
                                                               'credentials-secret')
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = str2bool(os.environ.get('SOCIAL_AUTH_REDIRECT_IS_HTTPS', False))
+
+JWT_AUTH['JWT_ISSUERS'].append({
+    'AUDIENCE': 'lms-key',
+    'ISSUER': 'http://edx.devstack.lms:18000/oauth2',
+    'SECRET_KEY': 'lms-secret',
+})


### PR DESCRIPTION
Support creating course certificates when a POST is made from the LMS.

This renames the API serialization of course_run_id to course_run_key, but that's fine, since that serialization is like a week old and no one is using it.

https://openedx.atlassian.net/browse/LEARNER-5050