### PR TITLE
Use bootstrap a little bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - docker --version
 
   # Build the image.
-  - docker-compose build > /dev/null
+  - docker-compose build
 
   # Ensure we have a place to store coverage output
   - mkdir -p coverage

--- a/credentials/apps/credentials_theme_openedx/static/sass/_components-rendering.scss
+++ b/credentials/apps/credentials_theme_openedx/static/sass/_components-rendering.scss
@@ -24,7 +24,7 @@
     font-size: rem(52);
     letter-spacing: .26em; // letterspacing relates to element font-size
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
+    @include media-breakpoint-up(md) {
       @include margin-left(0);
         font-size: rem(60);
     }
@@ -34,7 +34,7 @@
     display: block;
     font-size: rem(20);
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
+    @include media-breakpoint-up(md) {
       font-size: rem(23);
     }
   }
@@ -73,7 +73,7 @@
     display: block;
     margin: spacing-vertical(base) auto;
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
+    @include media-breakpoint-up(md) {
       display: inline-block;
       max-width: span(4 of 12);
       margin: 0;
@@ -90,7 +90,7 @@
     display: block;
     margin: spacing-vertical(base) auto;
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
+    @include media-breakpoint-up(md) {
       display: inline-block;
       max-width: span(6 of 12);
       margin: 0;
@@ -112,7 +112,7 @@
     color: $headings-emphasized-color;
     font-weight: $headings-font-weight-bold;
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
+    @include media-breakpoint-up(md) {
       font-size: rem(40);
     }
   }
@@ -124,7 +124,7 @@
     color: $headings-emphasized-color;
     font-weight: $headings-font-weight-bold;
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
+    @include media-breakpoint-up(md) {
       font-size: font-size(xxx-large); // @extend %hd-2; extends not working
     }
   }
@@ -132,7 +132,7 @@
   .copy {
     @extend %copy-meta;
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
+    @include media-breakpoint-up(md) {
       font-size: font-size(large); // @extend %copy-large; extends not working
     }
   }

--- a/credentials/apps/credentials_theme_openedx/static/sass/_config.scss
+++ b/credentials/apps/credentials_theme_openedx/static/sass/_config.scss
@@ -6,4 +6,5 @@
 // ------------------------------
 // #VARIABLES
 // ------------------------------
+$output-bourbon-deprecation-warnings: false;
 $font-path: '~edx-pattern-library/pattern-library/fonts';

--- a/credentials/apps/credentials_theme_openedx/static/sass/_layouts-rendering.scss
+++ b/credentials/apps/credentials_theme_openedx/static/sass/_layouts-rendering.scss
@@ -16,7 +16,7 @@
   background-color: palette(grayscale, white);
   text-align: center;
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
+  @include media-breakpoint-up(md) {
     @include text-align(left);
     padding: 5% 5% 3%;
   }
@@ -52,7 +52,7 @@
       width: 250px;
     }
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
+    @include media-breakpoint-up(md) {
       display: inline-block;
       vertical-align: middle;
       width: span(6 of 12);
@@ -61,7 +61,7 @@
       }
     }
 
-    @include susy-breakpoint($bp-screen-lg, $susy) {
+    @include media-breakpoint-up(lg) {
       width: span(6 of 12);
       svg {
         width: 300px;
@@ -87,7 +87,7 @@
   margin-top: spacing-vertical(small);
   text-align: center;
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
+  @include media-breakpoint-up(md) {
     @include margin-left(gutter(inside));
     @include text-align(right);
     display: inline-block;
@@ -97,7 +97,7 @@
     margin-bottom: spacing-vertical(base);
   }
 
-  @include susy-breakpoint($bp-screen-lg, $susy) {
+  @include media-breakpoint-up(lg) {
     width: span(6 of 12);
   }
 }
@@ -108,7 +108,7 @@
   border-bottom: 1px solid palette(grayscale-cool, light);
   padding-bottom: spacing-vertical(small);
 
-  @include susy-breakpoint($bp-screen-lg, $susy) {
+  @include media-breakpoint-up(lg) {
     display: inline-block;
     vertical-align: middle;
     width: span(8 of 12);
@@ -131,7 +131,7 @@
   border-bottom: 1px solid palette(grayscale-cool, light);
   padding-bottom: spacing-vertical(small);
 
-  @include susy-breakpoint($bp-screen-lg, $susy) {
+  @include media-breakpoint-up(lg) {
     @include margin-left(gutter(inside));
     @include text-align(right);
     display: inline-block;
@@ -146,11 +146,11 @@
   @include gallery(12 of 12);
   float: none; // unset the gallery float to prevent overlap
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
+  @include media-breakpoint-up(md) {
     @include gallery(6 of 12);
   }
 
-  @include susy-breakpoint($bp-screen-lg, $susy) {
+  @include media-breakpoint-up(lg) {
     @include gallery(12 of 12);
     float: none; // unset the gallery float to prevent overlap
   }
@@ -173,7 +173,7 @@
       margin-top: 2px;
     }
 
-    @include susy-breakpoint($bp-screen-lg, $susy) {
+    @include media-breakpoint-up(lg) {
       display: inline-block;
       vertical-align: middle;
       @include margin-right(25px);
@@ -184,7 +184,7 @@
   .accomplishment-stamp-date {
     margin-bottom: 10px;
 
-    @include susy-breakpoint($bp-screen-lg, $susy) {
+    @include media-breakpoint-up(lg) {
       display: inline-block;
       vertical-align: middle;
       @include margin-right(25px);
@@ -194,7 +194,7 @@
   .accomplishment-stamp-validity {
     margin-bottom: 10px;
 
-    @include susy-breakpoint($bp-screen-lg, $susy) {
+    @include media-breakpoint-up(lg) {
       display: inline-block;
       vertical-align: middle;
       @include margin-right(25px);
@@ -204,7 +204,7 @@
   .accomplishment-stamp-effort {
     margin-bottom: 10px;
 
-    @include susy-breakpoint($bp-screen-lg, $susy) {
+    @include media-breakpoint-up(lg) {
       display: inline-block;
       vertical-align: middle;
     }

--- a/credentials/apps/credentials_theme_openedx/static/sass/_lib.scss
+++ b/credentials/apps/credentials_theme_openedx/static/sass/_lib.scss
@@ -7,3 +7,5 @@
 // TODO (CCB): Update edx-pattern-library to get rid of susy.
 @import '~susy/sass/susy';
 @import '~breakpoint-sass/stylesheets/breakpoint';
+
+@import '~bootstrap/scss/bootstrap';

--- a/credentials/apps/credentials_theme_openedx/static/sass/_utilities.scss
+++ b/credentials/apps/credentials_theme_openedx/static/sass/_utilities.scss
@@ -28,6 +28,6 @@ $edx-x-color: #209fda;
 }
 
 %divider-2 {
-    border-bottom-width: rem(2);
+    border-bottom-width: 2rem;
     border-bottom-style: solid;
 }

--- a/credentials/static/sass/_components.scss
+++ b/credentials/static/sass/_components.scss
@@ -16,7 +16,7 @@
 .wrapper-header {
     @extend %divider-2;
     border-bottom-color: palette(grayscale, xx-trans);
-    background: palette(grayscale, white-t);
+    background: $white;
 }
 
 .header-app {
@@ -40,28 +40,28 @@
 .banner-user {
 
     .message-title {
-        @extend %hd-6;
+        @extend .h6;
         color: palette(grayscale, white);
-        font-weight: font-weight(semi-bold);
+        font-weight: $font-weight-bold;
 
-        @include susy-breakpoint($bp-screen-md, $susy) {
-            font-size: font-size(large); // @extend %hd-5;
+        @include media-breakpoint-up(md) {
+            font-size: $font-size-lg; // @extend %hd-5;
         }
     }
 
     .message-copy {
-        @extend %copy-meta;
+        @extend %text-meta;
         color: palette(grayscale, white);
 
-        @include susy-breakpoint($bp-screen-md, $susy) {
-          font-size: font-size(base);
+        @include media-breakpoint-up(md) {
+            font-size: $font-size-base;
         }
     }
 
     .message-actions-box {
       display: inline-block;
       border: 1px solid palette(grayscale, white);
-      border-radius: $component-border-radius;
+      border-radius: $card-border-radius;
       background-color: palette(grayscale, x-light);
       padding: spacing-vertical(xx-small) spacing-horizontal(x-small);
     }
@@ -97,7 +97,7 @@
         &.icon-only {
 
             .action-label {
-                @extend %a11y-hide;
+                @extend .sr-only;
             }
         }
 
@@ -128,7 +128,7 @@
 // #SUPPORT
 // ------------------------------
 .support-copy {
-  @extend %copy-meta;
+  @extend %text-meta;
 }
 
 .accomplishment-metadata-title {
@@ -136,15 +136,15 @@
 }
 
 .accomplishment-metadata-copy {
-  @extend %copy-meta;
+  @extend %text-meta;
 
   .metadata-copy-list {
-    @extend %list-unstyled;
+    @extend .list-unstyled;
     margin-bottom: spacing-vertical(small);
   }
 
   .emphasized {
-    font-weight: font-weight(bold);
+    font-weight: $font-weight-bold;
   }
 }
 
@@ -159,7 +159,7 @@
 .footer-app-nav {
 
     .list {
-        @extend %list-unstyled;
+        @extend .list-unstyled;
 
         .nav-item {
           display: inline-block;

--- a/credentials/static/sass/_config.scss
+++ b/credentials/static/sass/_config.scss
@@ -6,5 +6,6 @@
 // ------------------------------
 // #VARIABLES
 // ------------------------------
+$output-bourbon-deprecation-warnings: false;
 $fa-font-path: '~font-awesome/fonts';
 $font-path: '~edx-pattern-library/pattern-library/fonts';

--- a/credentials/static/sass/_layouts.scss
+++ b/credentials/static/sass/_layouts.scss
@@ -16,11 +16,11 @@
 // ------------------------------
 %layout-wrapper {
     margin-bottom: spacing-vertical(base);
-    padding: 0 (gutter()*2);
+    padding: 0 ($spacer*2);
 }
 
 %layout {
-    @include container();
+  @extend .container;
 }
 
 // ------------------------------
@@ -32,7 +32,7 @@
 }
 
 .header-app {
-  @extend %grid-container;
+  @extend .container;
   margin: 0 auto;
   padding: 17px 2%; // imitate LMS header spacing
 
@@ -58,28 +58,33 @@
 // #USER SHARE BANNER
 // ------------------------------
 .banner-user {
-  @extend %grid-container;
+  @extend .container;
   margin: 0 auto;
 
   .message-block {
+    @extend .row;
     margin: 0 2%;
     padding: spacing-vertical(small) 2%;
+    padding-bottom: 0; // message-text handles this for us, don't double up
   }
 
   .message-text {
+    @include make-col-ready();
     text-align: center;
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
-      @include span(8 of 12 first);
+    @include media-breakpoint-up(md) {
+      @include make-col(8);
       text-align: left;
     }
   }
 
   .message-actions {
+    @include make-col-ready();
+    padding-bottom: spacing-vertical(small);
     text-align: center;
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
-      @include span(4 of 12 last);
+    @include media-breakpoint-up(md) {
+      @include make-col(4);
       @include text-align(right);
     }
   }
@@ -90,7 +95,9 @@
 // #ACCOMPLISHMENT
 // ------------------------------
 .accomplishment {
-  @extend %grid-container;
+  @include make-container-max-widths();
+  width: 100%;
+  margin: 0 auto;
 }
 
 
@@ -98,8 +105,8 @@
 // #RECORDS
 // ------------------------------
 .record, .program-record {
-  @extend %grid-container;
-  background-color: palette(grayscale, white-t);
+  @extend .container;
+  background-color: $white;
   margin-top: 2em;
   margin-bottom: 2em;
   padding: 2em;
@@ -131,13 +138,13 @@
 // FoldingTable
 .folding-table-big {
   display: none;
-  @include susy-breakpoint($bp-screen-md, $susy) {
+  @include media-breakpoint-up(md) {
     display: block;
   }
 }
 
 .folding-table-small {
-  @include susy-breakpoint($bp-screen-md, $susy) {
+  @include media-breakpoint-up(md) {
     display: none;
   }
 }
@@ -150,38 +157,48 @@
 // #SUPPORT
 // ------------------------------
 .accomplishment-support {
-  @extend %grid-container;
-  margin: 0 3%;
+  @extend .container;
+  @extend .row;
+  margin: 0 auto;
   padding: 0 spacing-horizontal(base);
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
-    margin: 0 auto;
+  @include media-breakpoint-up(md) {
     padding: 0 spacing-horizontal(mid-large);
   }
 }
 
+.accomplishment-support-print {
+  @include make-col-ready();
+
+  @include media-breakpoint-up(md) {
+    @include make-col(12);
+  }
+}
+
 .accomplishment-metadata {
-  @extend %grid-container;
-  margin: 0 3%;
+  @extend .container;
+  @extend .row;
+  margin: 0 auto;
   padding: spacing-vertical(x-small) spacing-horizontal(base);
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
-    margin: 0 auto;
+  @include media-breakpoint-up(md) {
     padding: spacing-vertical(x-small) spacing-horizontal(mid-large);
   }
 }
 
 .accomplishment-metadata-aboutplatform {
+  @include make-col-ready();
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
-    @include span(6 of 12 first);
+  @include media-breakpoint-up(md) {
+    @include make-col(6);
   }
 }
 
 .accomplishment-metadata-aboutcert {
+  @include make-col-ready();
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
-    @include span(6 of 12 last);
+  @include media-breakpoint-up(md) {
+    @include make-col(6);
   }
 }
 
@@ -189,18 +206,19 @@
 // #FOOTER
 // ------------------------------
 .footer-app {
-  @extend %grid-container;
-  margin: 0 3%;
-  border-top: rem(4) solid palette(grayscale-cool, x-light);
+  @extend .container;
+  @extend .row;
+  margin: 0 auto;
+  border-top: $hr-border-width solid $hr-border-color;
   padding: spacing-vertical(small) spacing-horizontal(base);
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
-    margin: 0 auto;
+  @include media-breakpoint-up(md) {
     padding: spacing-vertical(small) spacing-horizontal(mid-large);
   }
 }
 
 .footer-app-legal {
+  @include make-col-ready();
 
   .copyright-trademarks {
     margin-top: spacing-vertical(small);
@@ -210,15 +228,16 @@
     }
   }
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
-    @include span(6 of 12 first);
+  @include media-breakpoint-up(md) {
+    @include make-col(6);
   }
 }
 
 .footer-app-related {
+  @include make-col-ready();
 
-  @include susy-breakpoint($bp-screen-md, $susy) {
-    @include span(6 of 12 last);
+  @include media-breakpoint-up(md) {
+    @include make-col(6);
     @include text-align(right);
   }
 }

--- a/credentials/static/sass/_lib.scss
+++ b/credentials/static/sass/_lib.scss
@@ -7,3 +7,5 @@
 // TODO (CCB): Update edx-pattern-library to get rid of susy.
 @import '~susy/sass/susy';
 @import '~breakpoint-sass/stylesheets/breakpoint';
+
+@import '~bootstrap/scss/bootstrap';

--- a/credentials/static/sass/_utilities.scss
+++ b/credentials/static/sass/_utilities.scss
@@ -31,6 +31,11 @@ $edx-x-color: #209fda;
 }
 
 %divider-2 {
-    border-bottom-width: rem(2);
+    border-bottom-width: 2rem;
     border-bottom-style: solid;
+}
+
+%text-meta {
+  font-size: $font-size-sm;
+  line-height: $line-height-lg;
 }

--- a/credentials/static/sass/_views.scss
+++ b/credentials/static/sass/_views.scss
@@ -1,18 +1,18 @@
 .certificate {
   .accomplishment-rendering {
-    background-color: palette(grayscale, white-t);
+    background-color: $white;
     background-repeat: no-repeat;
     background-position: center 30px;
     background-size: 80% auto;
     overflow: hidden;
     position: relative;
 
-    @include susy-breakpoint($bp-screen-md, $susy) {
+    @include media-breakpoint-up(md) {
       background-position: center 40px;
       background-size: 50% auto;
     }
 
-    @include susy-breakpoint($bp-screen-lg, $susy) {
+    @include media-breakpoint-up(lg) {
       background-position: -325px -50px;
       background-size: 100% auto;
     }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "bootstrap": "4.0.0-alpha.6",
     "css-loader": "^0.27.3",
     "edx-pattern-library": "0.16.1",
     "extract-text-webpack-plugin": "^2.1.0",


### PR DESCRIPTION
Start using bootstrap instead of edx-pattern-library in a few places. We eventually want to get rid of the pattern library altogether. But baby steps.

This branch mostly just changes some base styling and bits of the openedx them to use less pattern-library code. I didn't touch the edx theme in credentials-themes.

I've tested this on mobile (firefox and safari) and desktop (firefox and chromium so far).
I've tested the openedx and edx.org themes. The edx.org one needed no changes, so I don't think we'll break any other custom themes.
I've tested by looking at the example certificate and also confirmed that we didn't break the early-stages records work we have.

I am using an old version of bootstrap (v4 alpha 6, which paragon used to use) because newer versions caused some conflicts with edx-pattern-library that I was having trouble resolving. As we remove more and more of it, hopefully when we're done we can bump the bootstrap version to be more modern. Baby steps.

You can compare and contrast on this sandbox: https://credentials-mikix.sandbox.edx.org/credentials/example/

Or these basic images:
Old:
![old](https://user-images.githubusercontent.com/1196901/41118089-f5d461d2-6a5c-11e8-973c-9a7b1541d7ac.png)
New:
![new](https://user-images.githubusercontent.com/1196901/41118088-f5b8bb76-6a5c-11e8-8d28-55018724d6ac.png)