### PR TITLE
Sync full name on login

### DIFF
--- a/credentials/apps/core/tests/factories.py
+++ b/credentials/apps/core/tests/factories.py
@@ -17,6 +17,7 @@ class UserFactory(django.DjangoModelFactory):
     password = PostGenerationMethodCall('set_password', USER_PASSWORD)
     first_name = Faker('first_name')
     last_name = Faker('last_name')
+    full_name = Faker('name')
     email = Faker('safe_email')
     is_staff = False
     is_active = True

--- a/credentials/apps/core/tests/test_utils.py
+++ b/credentials/apps/core/tests/test_utils.py
@@ -1,0 +1,29 @@
+"""Test core.utils."""
+
+import mock
+from django.test import TestCase
+
+from credentials.apps.core.tests.factories import UserFactory
+from credentials.apps.core.utils import update_full_name
+
+
+class UtilsTests(TestCase):
+    """ Tests for the utility functions."""
+
+    def setUp(self):
+        super(UtilsTests, self).setUp()
+        self.user = UserFactory(full_name='Bart')
+
+    def test_update_full_name_no_user(self):
+        # Just test that we don't blow up
+        update_full_name(mock.MagicMock(), {})
+
+    def test_update_full_name_no_full_name(self):
+        # Just test that we don't blow up
+        update_full_name(mock.MagicMock(), {}, self.user)
+
+    def test_update_full_name_happy_path(self):
+        strategy = mock.MagicMock()
+        update_full_name(strategy, {'full_name': 'Bort'}, self.user)
+        self.assertEqual(self.user.full_name, 'Bort')
+        self.assertTrue(strategy.storage.user.changed.called)

--- a/credentials/apps/core/utils.py
+++ b/credentials/apps/core/utils.py
@@ -1,0 +1,12 @@
+""" Core utils. """
+
+
+# This function is used by our oauth2 authorization pipeline. See settings/base.py
+def update_full_name(strategy, details, user=None, *_args, **_kwargs):
+    """Update the user's full name using data from provider."""
+    if user:
+        full_name = details.get('full_name')
+
+        if full_name and user.full_name != full_name:
+            user.full_name = full_name
+            strategy.storage.user.changed(user)

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -304,6 +304,25 @@ OAUTH_ID_TOKEN_EXPIRATION = 60
 
 SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
 
+SOCIAL_AUTH_PIPELINE = (
+    # This first block is a copy of the default pipelines from auth_backends.strategies.EdxDjangoStrategy.
+    # We can't import that module here to reference the default set directly (circular dependencies), so we just
+    # duplicate it.
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.auth_allowed',
+    'social_core.pipeline.social_auth.social_user',
+    'auth_backends.pipeline.get_user_if_exists',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details',
+    'auth_backends.pipeline.update_email',
+
+    # Credentials-specific pipeline below
+    'credentials.apps.core.utils.update_full_name',
+)
+
 # Set these to the correct values for your OAuth2/OpenID Connect provider (e.g., devstack)
 SOCIAL_AUTH_EDX_OIDC_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OIDC_SECRET = 'replace-me'


### PR DESCRIPTION
We already synced the username and email, but we also want the full name, which we'll display on student records.

This isn't necessarily something we want to push upstream to EdxDjangoStrategy, because the full_name field is a Credentials addition. So not sure we can rely on that field being there for other IDAs.

https://openedx.atlassian.net/browse/LEARNER-5304