### PR TITLE
Added check for public/private view

### DIFF
--- a/credentials/static/components/ProgramRecord.jsx
+++ b/credentials/static/components/ProgramRecord.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@edx/paragon';
+// import Cookies from 'js-cookie';
 
 import FoldingTable from './FoldingTable';
 import SendLearnerRecordModal from './SendLearnerRecordModal';
@@ -16,6 +17,12 @@ class ProgramRecord extends React.Component {
     this.closeSendRecordModal = this.closeSendRecordModal.bind(this);
     this.closeShareModel = this.closeShareModel.bind(this);
     this.setActiveButton = this.setActiveButton.bind(this);
+
+    // TODO: uncomment when implementing LEARNER-5550, as well as the Cookies import above
+    // const userCookie = Cookies.get('edx-user-info');
+    // this.isPublic = !userCookie ||
+    //  (StringUtils.parseDirtyJSON(userCookie).username !== props.learner.username);
+
     this.state = {
       shareModelOpen: false,
       sendRecordModalOpen: false,
@@ -174,7 +181,11 @@ class ProgramRecord extends React.Component {
 }
 
 ProgramRecord.propTypes = {
-  learner: PropTypes.shape({}).isRequired,
+  learner: PropTypes.shape({
+    email: PropTypes.string,
+    full_name: PropTypes.string,
+    username: PropTypes.string,
+  }).isRequired,
   program: PropTypes.shape({
     name: PropTypes.string,
     school: PropTypes.string,

--- a/credentials/static/components/Utils.jsx
+++ b/credentials/static/components/Utils.jsx
@@ -25,6 +25,11 @@ class StringUtils {
       <span dangerouslySetInnerHTML={{ __html: htmlString }} />
     );
   }
+  // Parses a JSON string that contains encoded commas and escaped quotes around keys/values
+  // edx-user-info cookie is an example of where this is needed
+  static parseDirtyJSON(jsonString) {
+    return JSON.parse(jsonString.replace(/\\"/g, '"').replace(/\\054/g, ','));
+  }
 }
 
 export default StringUtils;

--- a/credentials/static/components/specs/ProgramRecord.test.jsx
+++ b/credentials/static/components/specs/ProgramRecord.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import ProgramRecord from '../ProgramRecord';
+import StringUtils from '../Utils';
 
 let wrapper;
 
@@ -40,6 +41,9 @@ const defaultProps = {
   platform_name: 'testX',
   loadModalsAsChildren: false,
 };
+
+// eslint-disable-next-line no-useless-escape
+const cookieJSON = '{\"username\": \"edx\"\\054 \"version\": 1\\054 \"header_urls\": {\"learner_profile\": \"http://localhost:18000/u/edx\"\\054 \"resume_block\": \"sample\"}}';
 
 describe('<ProgramRecord />', () => {
   beforeEach(() => {
@@ -99,5 +103,13 @@ describe('<ProgramRecord />', () => {
     wrapper.update();
     expect(wrapper.find('.modal-dialog').length).toBe(0);
     expect(wrapper.find('#program-record-actions button.btn-secondary').html()).toEqual(document.activeElement.outerHTML);
+  });
+
+  it('correctly parses cookie JSON', () => {
+    const parsed = StringUtils.parseDirtyJSON(cookieJSON);
+
+    expect(parsed.username).toEqual('edx');
+    expect(parsed.version).toBe(1);
+    expect(parsed.header_urls.resume_block).toBe('sample');
   });
 });


### PR DESCRIPTION
Added a boolean field to indicate whether the public or private view should be visible. It is private if the program record is associated with the current logged in user (checked via cookie), and public otherwise. This has been commented out to pass code coverage for now, will be used for LEARNER-5550.

Also added a utility function for parsing the 'edx-user-info' cookie as its JSON string contains escaped quotes and encoded commas which break JSON.parse().