### PR TITLE
Fix font awesome svg inline loading in css.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,17 @@ module.exports = {
             },
             {
                 test: /\.svg$/,
-                loader: 'svg-inline-loader',
+                oneOf: [
+
+                    {
+                        exclude: path.resolve('./credentials/static/bundles/fonts/'),
+                        use: 'file-loader'
+                    },
+                    {
+                        include: path.resolve('./credentials/static/images/'),
+                        use: 'svg-inline-loader'
+                    }
+                ]
             }
         ]
     },


### PR DESCRIPTION
ManifestStaticFilesStorage on prod raising file not found error
for font awesome svg files. Fixed by not loading them inline and
use file-loader instead.

This issue started appearing after merging https://github.com/edx/credentials/pull/435.

LEARNER-5722