### PR TITLE
Adds records analytics

### DIFF
--- a/credentials/static/components/Analytics.jsx
+++ b/credentials/static/components/Analytics.jsx
@@ -1,0 +1,11 @@
+// Function that wraps analytics.track so that it can be also be called directly
+function trackEvent(name, properties) {
+  // Only load the key if it has been injected into the page already
+  // This enables easy testing that doesn't create GA events
+  if (window.analytics) {
+    window.analytics.track(name, properties);
+  }
+}
+
+
+export default trackEvent;

--- a/credentials/static/components/ProgramRecord.jsx
+++ b/credentials/static/components/ProgramRecord.jsx
@@ -8,6 +8,7 @@ import ProgramIcon from './ProgramIcon';
 import SendLearnerRecordModal from './SendLearnerRecordModal';
 import ShareProgramRecordModal from './ShareProgramRecordModal';
 import StringUtils from './Utils';
+import trackEvent from './Analytics';
 
 class ProgramRecord extends React.Component {
   constructor(props) {
@@ -54,6 +55,10 @@ class ProgramRecord extends React.Component {
       sendRecordModalOpen: true,
     });
     this.setActiveButton(event.target);
+    trackEvent('edx.bi.credentials.program_record.send_started', {
+      category: 'records',
+      'program-uuid': this.props.uuid,
+    });
   }
 
   loadShareModel(event) {
@@ -61,6 +66,10 @@ class ProgramRecord extends React.Component {
       shareModelOpen: true,
     });
     this.setActiveButton(event.target);
+    trackEvent('edx.bi.credentials.program_record.share_started', {
+      category: 'records',
+      'program-uuid': this.props.uuid,
+    });
   }
 
   closeSendRecordModal() {
@@ -224,6 +233,7 @@ class ProgramRecord extends React.Component {
           <SendLearnerRecordModal
             {...defaultModalProps}
             onClose={this.closeSendRecordModal}
+            uuid={uuid}
           />
         }
         {shareModelOpen &&

--- a/credentials/static/components/SendLearnerRecordModal.jsx
+++ b/credentials/static/components/SendLearnerRecordModal.jsx
@@ -2,8 +2,9 @@ import 'babel-polyfill'; // Needed to support Promises on legacy browsers
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, CheckBoxGroup, CheckBox, Modal } from '@edx/paragon';
+import trackEvent from './Analytics';
 
-class ShareProgramRecordModal extends React.Component {
+class SendLearnerRecordModal extends React.Component {
   constructor(props) {
     super(props);
     this.sendRecord = this.sendRecord.bind(this);
@@ -14,15 +15,30 @@ class ShareProgramRecordModal extends React.Component {
     };
   }
 
-  sendRecord() {
-    this.setState({
-      recordSent: true,
-    });
+  // Get the organizations we are sharing for the analytics event
+  // TODO: remove hardcoded values once the state is no longer hardcoded
+  getCheckedOrganizations() {
+    const organizations = [];
+
+    if (this.state.RIT) { organizations.push('RIT'); }
+    if (this.state.MIT) { organizations.push('MIT'); }
+    return organizations;
   }
 
   updateState(checked, name) {
     this.setState({
       [name]: !this.state[name],
+    });
+  }
+
+  sendRecord() {
+    this.setState({
+      recordSent: true,
+    });
+    trackEvent('edx.bi.credentials.program_record.send_finished', {
+      category: 'records',
+      'program-uuid': this.props.uuid,
+      organizations: this.getCheckedOrganizations(),
     });
   }
 
@@ -69,17 +85,18 @@ class ShareProgramRecordModal extends React.Component {
   }
 }
 
-ShareProgramRecordModal.propTypes = {
+SendLearnerRecordModal.propTypes = {
   onClose: PropTypes.func,
   parentSelector: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.bool,
   ]),
+  uuid: PropTypes.string.isRequired,
 };
 
-ShareProgramRecordModal.defaultProps = {
+SendLearnerRecordModal.defaultProps = {
   onClose: () => {},
   parentSelector: false,
 };
 
-export default ShareProgramRecordModal;
+export default SendLearnerRecordModal;

--- a/credentials/static/components/ShareProgramRecordModal.jsx
+++ b/credentials/static/components/ShareProgramRecordModal.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import Cookies from 'js-cookie';
 import { Button, Icon, InputText, Modal, StatusAlert } from '@edx/paragon';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import trackEvent from './Analytics';
 
 class ShareProgramRecordModal extends React.Component {
   constructor(props) {
@@ -114,6 +115,10 @@ class ShareProgramRecordModal extends React.Component {
                   <Button
                     label={gettext('Copy Link')}
                     className={['btn-primary']}
+                    onClick={trackEvent('edx.bi.credential.program_record.share_url_copied', {
+                      category: 'records',
+                      'program-uuid': this.props.uuid,
+                    })}
                   />
                 </CopyToClipboard>
               </div>

--- a/credentials/static/components/specs/Analytics.test.jsx
+++ b/credentials/static/components/specs/Analytics.test.jsx
@@ -1,0 +1,21 @@
+import trackEvent from '../Analytics';
+
+
+let mockAnalytics;
+
+describe('Track Event', () => {
+  beforeEach(() => {
+    mockAnalytics = jest.fn();
+  });
+
+  it('calls window analytics function if it exists', () => {
+    window.analytics = { track: mockAnalytics };
+    const eventName = 'testEvent';
+    const eventProperties = { category: 'test' };
+    trackEvent(eventName, eventProperties);
+
+    expect(mockAnalytics.mock.calls.length).toBe(1);
+    expect(mockAnalytics.mock.calls[0][0]).toBe(eventName);
+    expect(mockAnalytics.mock.calls[0][1]).toBe(eventProperties);
+  });
+});

--- a/credentials/static/components/specs/SendLearnerRecordModal.test.jsx
+++ b/credentials/static/components/specs/SendLearnerRecordModal.test.jsx
@@ -6,6 +6,7 @@ let wrapper;
 
 const defaultProps = {
   parentSelector: 'body',
+  uuid: 'test-uuid',
 };
 
 describe('<SendLearnerRecordModal />', () => {
@@ -38,5 +39,11 @@ describe('<SendLearnerRecordModal />', () => {
     wrapper.find('.modal-footer button.btn-primary').simulate('click');
     wrapper.update();
     expect(wrapper.state('recordSent')).toBe(true);
+  });
+
+  it('gets the correct checked organizations', () => {
+    wrapper.find('.modal-body input').at(0).simulate('change', { target: { checked: true } });
+    expect(wrapper.state('RIT')).toBe(true);
+    expect(wrapper.instance().getCheckedOrganizations()).toEqual(['RIT']);
   });
 });

--- a/credentials/static/js/analytics.js
+++ b/credentials/static/js/analytics.js
@@ -3,9 +3,11 @@
  *
  * Emits a tracking event via window.analytics.track().
  */
-function handleClick() {
-  const attributes = this.attributes;
-  const eventName = this.getAttribute('data-track-event');
+function handleClick(event) {
+  const target = event.target;
+
+  const attributes = target.attributes;
+  const eventName = target.getAttribute('data-track-event');
   const eventProperties = {};
   const eventPropertyPrefix = 'data-track-event-property-';
 
@@ -30,8 +32,6 @@ function setupClickHandlers() {
 
   for (let i = 0, len = clickElements.length; i < len; i += 1) {
     const clickElement = clickElements[i];
-
-
     clickElement.addEventListener('click', handleClick);
   }
 }
@@ -41,8 +41,8 @@ function setupClickHandlers() {
 /*eslint-enable*/
 
   analytics.load(window.edx.segment.key);
-  analytics.page();
 
+  analytics.page();
   setupClickHandlers();
 }
 }();


### PR DESCRIPTION
[LEARNER-5650](https://github.com/edx/credentials/tree/spencerhance/LEARNER-5650-add-records-analytics)

Implements all of the [new GA metrics](https://openedx.atlassian.net/wiki/spaces/AN/pages/779944554/Student+Records?focusedCommentId=789217308#comment-789217308) except for download_started and download_finished which need to be done in the Django API (via [LEARNER-5513](https://openedx.atlassian.net/browse/LEARNER-5513))