### PR TITLE
Updated backend to support public views at separate URL

### DIFF
--- a/credentials/apps/records/tests/factories.py
+++ b/credentials/apps/records/tests/factories.py
@@ -2,6 +2,8 @@ import factory
 from factory.fuzzy import FuzzyChoice, FuzzyDecimal
 
 from credentials.apps.catalog.tests.factories import CourseRunFactory
+from credentials.apps.core.tests.factories import UserFactory
+from credentials.apps.credentials.tests.factories import ProgramCertificateFactory
 from credentials.apps.records import models
 
 
@@ -14,3 +16,11 @@ class UserGradeFactory(factory.django.DjangoModelFactory):
     letter_grade = FuzzyChoice(['A', 'B', 'C', 'D', 'F'])
     percent_grade = FuzzyDecimal(0.0, 1.0, precision=4)
     verified = True
+
+
+class ProgramCertRecordFactory(factory.django.DjangoModelFactory):
+    class Meta(object):
+        model = models.ProgramCertRecord
+
+    certificate = factory.SubFactory(ProgramCertificateFactory)
+    user = factory.SubFactory(UserFactory)

--- a/credentials/apps/records/urls.py
+++ b/credentials/apps/records/urls.py
@@ -6,6 +6,9 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.RecordsView.as_view(), name='index'),
-    url(r'^programs/{uuid}/$'.format(uuid=UUID_PATTERN), views.ProgramRecordView.as_view(), name='programs'),
-    url(r'^new/$', views.ProgramRecordCreationView.as_view(), name='cert_creation')
+    url(r'^programs/{uuid}/$'.format(uuid=UUID_PATTERN), views.ProgramRecordView.as_view(), {'is_public': False},
+        name='private_programs'),
+    url(r'^programs/shared/{uuid}/$'.format(uuid=UUID_PATTERN), views.ProgramRecordView.as_view(), {'is_public': True},
+        name='public_programs'),
+    url(r'^new/$', views.ProgramRecordCreationView.as_view(), name='cert_creation'),
 ]


### PR DESCRIPTION
- Created new url for public views
- Updated get_record() to work with public views (there's an extra layer)
- Updated the context data to pass along the is_public boolean to the front end for button rendering
- Updated tests, added ProgramCertRecord factory