### PR TITLE
Updated front end to use public/private prop

### DIFF
--- a/credentials/static/components/ProgramRecord.jsx
+++ b/credentials/static/components/ProgramRecord.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@edx/paragon';
-import Cookies from 'js-cookie';
 
 import FoldingTable from './FoldingTable';
 import ProgramIcon from './ProgramIcon';
@@ -30,20 +29,6 @@ class ProgramRecord extends React.Component {
       isPublic: true,
       recordDownloaded: false,
     };
-  }
-
-  componentDidMount() {
-    this.setUser();
-  }
-
-  setUser() {
-    const userCookie = Cookies.get('prod-edx-user-info');
-    const { learner } = this.props;
-
-    this.setState({
-      isPublic: !userCookie ||
-        (StringUtils.parseDirtyJSON(userCookie).username !== learner.username),
-    });
   }
 
   setActiveButton(button) {
@@ -131,10 +116,11 @@ class ProgramRecord extends React.Component {
       learner,
       program,
       platform_name: platformName,
+      isPublic,
       uuid,
       loadModalsAsChildren,
     } = this.props;
-    const { sendRecordModalOpen, shareModelOpen, isPublic } = this.state;
+    const { sendRecordModalOpen, shareModelOpen } = this.state;
     const recordWrapperClass = 'program-record-wrapper';
     const defaultModalProps = {
       ...(loadModalsAsChildren && { parentSelector: `.${recordWrapperClass}` }),
@@ -263,12 +249,14 @@ ProgramRecord.propTypes = {
     last_updated: PropTypes.string,
   }).isRequired,
   grades: PropTypes.arrayOf(PropTypes.object).isRequired,
+  isPublic: PropTypes.bool,
   uuid: PropTypes.string.isRequired,
   platform_name: PropTypes.string.isRequired,
   loadModalsAsChildren: PropTypes.bool,
 };
 
 ProgramRecord.defaultProps = {
+  isPublic: true,
   loadModalsAsChildren: true,
 };
 

--- a/credentials/static/components/ProgramRecordFactory.jsx
+++ b/credentials/static/components/ProgramRecordFactory.jsx
@@ -20,6 +20,7 @@ function getUUID() {
 function ProgramRecordFactory(parent, props) {
   const formattedProps = {
     ...props.record,
+    isPublic: props.isPublic,
     uuid: getUUID(),
   };
 

--- a/credentials/static/components/Utils.jsx
+++ b/credentials/static/components/Utils.jsx
@@ -25,11 +25,6 @@ class StringUtils {
       <span dangerouslySetInnerHTML={{ __html: htmlString }} />
     );
   }
-  // Parses a JSON string that contains encoded commas and escaped quotes around keys/values
-  // edx-user-info cookie is an example of where this is needed
-  static parseDirtyJSON(jsonString) {
-    return JSON.parse(jsonString.replace(/\\"/g, '"').replace(/\\054/g, ','));
-  }
 }
 
 export default StringUtils;

--- a/credentials/static/components/specs/ProgramRecord.test.jsx
+++ b/credentials/static/components/specs/ProgramRecord.test.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import Cookies from 'js-cookie';
 import ProgramRecord from '../ProgramRecord';
-import StringUtils from '../Utils';
 
 let wrapper;
 
@@ -48,19 +46,17 @@ const defaultProps = {
       school: 'TestX',
     },
   ],
+  isPublic: false,
   uuid: '1a2b3c4d',
   platform_name: 'testX',
   loadModalsAsChildren: false,
 };
 
-// eslint-disable-next-line no-useless-escape
-const cookieJSON = '{\"username\": \"edx\"\\054 \"version\": 1\\054 \"header_urls\": {\"learner_profile\": \"http://localhost:18000/u/edx\"\\054 \"resume_block\": \"sample\"}}';
 
 describe('<ProgramRecord />', () => {
   describe('User viewing own record', () => {
     beforeEach(() => {
       wrapper = mount(<ProgramRecord {...defaultProps} />);
-      wrapper.setState({ isPublic: false });
     });
 
     it('renders correct sections', () => {
@@ -135,20 +131,11 @@ describe('<ProgramRecord />', () => {
       expect(wrapper.find('.modal-dialog').length).toBe(0);
       expect(wrapper.find('.program-record-actions button.btn-secondary').html()).toEqual(document.activeElement.outerHTML);
     });
-
-    it('correctly parses cookie JSON', () => {
-      const parsed = StringUtils.parseDirtyJSON(cookieJSON);
-
-      expect(parsed.username).toEqual('edx');
-      expect(parsed.version).toBe(1);
-      expect(parsed.header_urls.resume_block).toBe('sample');
-    });
   });
 
   describe('Public view of record', () => {
     beforeEach(() => {
-      Cookies.set('prod-edx-user-info', cookieJSON, { path: '' });
-      wrapper = mount(<ProgramRecord {...defaultProps} />);
+      wrapper = mount(<ProgramRecord {...defaultProps} isPublic />);
     });
 
     it('renders correct sections', () => {

--- a/credentials/templates/programs.html
+++ b/credentials/templates/programs.html
@@ -23,6 +23,7 @@
   <script type="text/javascript">
     ProgramRecordFactory('program-record', {
       record: JSON.parse('{{record|escapejs}}'),
+      isPublic: {{ is_public|yesno:"true,false"}},
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
Previously the ProgramRecord view used a cookie to decide whether it should be public or private. This PR updates it to instead use a prop.