### PR TITLE
Handle node dependencies using --unsafe-perm.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ production-requirements: ## Install requirements for production
 	pip install -r requirements.txt
 
 requirements: ## Install requirements for local development
-	npm install
+	npm install --unsafe-perm ## This flag exists to force node-sass to build correctly on docker. Remove as soon as possible.
 	pip install -r requirements/local.txt
 
 quality: ## Run linters


### PR DESCRIPTION
This is for dealing with issues within docker and running everything from the docker root.

Other places where this issue has been mentioned (along with this fix): https://github.com/npm/npm/issues/17431
https://github.com/sass/node-sass/issues/2006

We need a more robust solution, but this is blocking any updates to `package.json` or `package-lock.json`.