### PR TITLE
Show all program courses in program record view

### DIFF
--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -3,10 +3,10 @@ import datetime
 import io
 import json
 import urllib.parse
-from analytics.client import Client as SegmentClient
 from collections import defaultdict
-import waffle
 
+import waffle
+from analytics.client import Client as SegmentClient
 from django import http
 from django.contrib.auth.mixins import AccessMixin, LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType


### PR DESCRIPTION
Updates the ProgramRecordView get request to return all program courses, even if they don't have a grade or cert for any associated course_runs.

If they don't have a verified cert, all table values except for Course name and org are left blank.

Additionally, the _Course_ title is used instead of the Course _run_ title when there are no certs for the associated course runs.