### PR TITLE
Added travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,30 @@ cache:
 before_install:
   - docker-compose -f docker-compose.yml -f docker-compose.travis.yml up -d
 
-# Doing so is a waste of time since they won't be used.
-install: true
+matrix:
+  include:
+    - env: TESTNAME=quality-and-translations
 
-script:
-  - make exec-requirements
-  - make exec-static
-  - make exec-check_translations_up_to_date
-  - make exec-validate-translations
-  - make exec-quality
-  - make exec-tests
+      # Doing so is a waste of time since they won't be used.
+      install: true
 
-after_success:
-  - pip install --upgrade codecov
-  - make exec-coverage
-  - codecov
+      script:
+        - make exec-requirements
+        - make exec-check_translations_up_to_date
+        - make exec-validate-translations
+        - make exec-quality
+
+    - env: TESTNAME=unit-tests
+
+      # Doing so is a waste of time since they won't be used.
+      install: true
+
+      script:
+        - make exec-requirements
+        - make exec-static
+        - make exec-tests
+
+      after_success:
+        - pip install --upgrade codecov
+        - make exec-coverage
+        - codecov


### PR DESCRIPTION
Saves an insignificant amount of time for overall time.

The main benefit we get is a clear split of what tests are being run.

![image](https://user-images.githubusercontent.com/7101723/43080289-6d5a641c-8e5d-11e8-95d3-963951caad1b.png)
