### PR TITLE
LEARNER-5814

### DIFF
--- a/credentials/apps/records/models.py
+++ b/credentials/apps/records/models.py
@@ -8,7 +8,6 @@ from django_extensions.db.models import TimeStampedModel
 
 from credentials.apps.catalog.models import CourseRun, Program
 from credentials.apps.core.models import User
-from credentials.apps.credentials.models import ProgramCertificate
 
 
 class UserGrade(TimeStampedModel):
@@ -29,7 +28,6 @@ class ProgramCertRecord(TimeStampedModel):
     """
     Connects a User with a Program
     """
-    certificate = models.ForeignKey(ProgramCertificate, null=True)
     program = models.ForeignKey(Program, null=True)
     user = models.ForeignKey(User)
     uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)


### PR DESCRIPTION
Remove certificate field from ProgramCertRecord.  Second to last stage of the migration process, to be followed by running the migration to remove certificate from the database.