### PR TITLE
LEARNER-5925 Add rate limiting to credentials records endpoint

### DIFF
--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -19,6 +19,7 @@ from credentials.apps.credentials.tests.factories import (CourseCertificateFacto
                                                           UserCredentialAttributeFactory, UserCredentialFactory)
 from credentials.apps.records.models import UserGrade
 from credentials.apps.records.tests.factories import UserGradeFactory
+from credentials.shared.log_checker import assert_log_correct
 
 JSON_CONTENT_TYPE = 'application/json'
 LOGGER_NAME = 'credentials.apps.credentials.issuers'
@@ -537,7 +538,12 @@ class ThrottlingTests(SiteMixin, APITestCase):
             # Request after limit should NOT be acceptable
             response = self.client.get(list_path)
             self.assertEqual(response.status_code, 429)
-            self.assert_throttling_log_correct(log, 'CredentialViewSet')
+            assert_log_correct(
+                log,
+                'credentials.apps.api.v2.views',
+                'WARNING',
+                'Credentials API endpoint CredentialViewSet is being throttled.',
+            )
 
     def test_grade_view_throttling(self):
         """ Verify requests are throttled and a message is logged after limit. """
@@ -566,7 +572,12 @@ class ThrottlingTests(SiteMixin, APITestCase):
             # Request after limit should NOT be acceptable
             response = getattr(self.client, 'put')(path, data=data)
             self.assertEqual(response.status_code, 429)
-            self.assert_throttling_log_correct(log, 'GradeViewSet')
+            assert_log_correct(
+                log,
+                'credentials.apps.api.v2.views',
+                'WARNING',
+                'Credentials API endpoint GradeViewSet is being throttled.',
+            )
 
     def test_staff_override(self):
         """ Verify a superuser does not get throttled for lower rate. """

--- a/credentials/apps/records/constants.py
+++ b/credentials/apps/records/constants.py
@@ -1,4 +1,5 @@
 WAFFLE_FLAG_RECORDS = 'student_records'
+RECORDS_RATE_LIMIT = '15/m'  # This rate was arbitrarily chosen due to a lack of data.  It may need to be changed later.
 
 
 class UserCreditPathwayStatus(object):

--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -15,6 +15,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from mock import patch
+from testfixtures import LogCapture
 from waffle.testutils import override_flag
 
 from credentials.apps.catalog.tests.factories import (CourseFactory, CourseRunFactory, CreditPathwayFactory,
@@ -30,8 +31,9 @@ from credentials.apps.records.models import ProgramCertRecord, UserCreditPathway
 from credentials.apps.records.tests.factories import (ProgramCertRecordFactory, UserCreditPathwayFactory,
                                                       UserGradeFactory)
 from credentials.apps.records.tests.utils import dump_random_state
+from credentials.shared.log_checker import assert_log_correct
 
-from ..constants import WAFFLE_FLAG_RECORDS
+from ..constants import RECORDS_RATE_LIMIT, WAFFLE_FLAG_RECORDS
 
 JSON_CONTENT_TYPE = 'application/json'
 
@@ -762,3 +764,89 @@ class ProgramRecordCsvViewTests(SiteMixin, TestCase):
         headers = ['course_id', 'percent_grade', 'attempts', 'school', 'issue_date', 'letter_grade', 'name']
         for header in headers:
             self.assertIn(header, csv_headers)
+
+
+@override_flag(WAFFLE_FLAG_RECORDS, active=True)
+class RecordsThrottlingTests(SiteMixin, TestCase):
+    """ Tests for throttling the records endpoint. """
+    USERNAME = "test-user"
+
+    def setUp(self):
+        super().setUp()
+        dump_random_state()
+        self.user = UserFactory(username=self.USERNAME)
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+        self.program = ProgramFactory(site=self.site)
+        self.rate_limit = self.parse_rate(RECORDS_RATE_LIMIT)
+
+    def post(self, url, json_data):
+        """ Helper for posting given data to a url. """
+        return self.client.post(url, data=json_data, content_type=JSON_CONTENT_TYPE)
+
+    def parse_rate(self, rate_limit):
+        """ Helper to get integer rate limit from string representation. """
+        count, _ = rate_limit.split('/')
+        return int(count)
+
+    def hit_rate_limit(self, attempts, endpoint, url, json_data):
+        """
+        Helper for just hitting, not exceeding the rate limit.
+
+        Note: There is a potential for any test using this helper to be flaky
+        in the case the endpoint we are testing slows down over time and/or the
+        rate limit is increased.
+        """
+        for _ in range(attempts):
+            response = self.post(url, json_data)
+            if endpoint == 'send_program':
+                # Delete credit pathway after post to enable resending email
+                UserCreditPathway.objects.all().delete()
+
+            self.assertEqual(response.status_code, 200)
+
+    def exceed_rate_limit(self, url, json_data):
+        """ Helper for making a request to exceed the rate limit. """
+        response = self.post(url, json_data)
+        self.assertEqual(response.status_code, 429)
+
+    def test_record_creation_throttling(self):
+        """ Verify endpoint is throttled and a message is logged after limit. """
+        with LogCapture() as log:
+            url = reverse('records:share_program', kwargs={'uuid': self.program.uuid.hex})
+            data = {'username': self.USERNAME}
+            json_data = json.dumps(data).encode('utf-8')
+
+            # All requests up to the rate limit should be acceptable
+            response = self.post(url, json_data)
+            self.assertEqual(response.status_code, 201)
+            self.hit_rate_limit(self.rate_limit - 1, 'share_program', url, json_data)
+
+            # Request after limit should NOT be acceptable
+            self.exceed_rate_limit(url, json_data)
+            assert_log_correct(
+                log,
+                'credentials.apps.records.views',
+                'WARNING',
+                'Credentials records endpoint is being throttled.',
+            )
+
+    def test_program_send_throttling(self):
+        """ Verify endpoint is throttled and a message is logged after limit. """
+        with LogCapture() as log:
+            ProgramCertificateFactory(site=self.site, program_uuid=self.program.uuid)
+            url = reverse('records:send_program', kwargs={'uuid': self.program.uuid.hex})
+            pathway = CreditPathwayFactory(site=self.site, programs=[self.program])
+            data = {'username': self.USERNAME, 'pathway_id': pathway.id}
+            json_data = json.dumps(data).encode('utf-8')
+
+            # All requests up to the rate limit should be acceptable
+            self.hit_rate_limit(self.rate_limit, 'send_program', url, json_data)
+
+            # Request after limit should NOT be acceptable
+            self.exceed_rate_limit(url, json_data)
+            assert_log_correct(
+                log,
+                'credentials.apps.records.views',
+                'WARNING',
+                'Credentials records endpoint is being throttled.',
+            )

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -80,6 +80,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
     'waffle.middleware.WaffleMiddleware',
+    'ratelimit.middleware.RatelimitMiddleware',
 )
 
 ROOT_URLCONF = 'credentials.urls'
@@ -380,6 +381,9 @@ REST_FRAMEWORK = {
     'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%SZ',
     'EXCEPTION_HANDLER': 'credentials.apps.api.v2.views.credentials_throttle_handler',
 }
+
+# Django-ratelimit Settings
+RATELIMIT_VIEW = 'credentials.apps.records.views.rate_limited'
 
 # DJANGO DEBUG TOOLBAR CONFIGURATION
 # http://django-debug-toolbar.readthedocs.org/en/latest/installation.html

--- a/credentials/shared/log_checker.py
+++ b/credentials/shared/log_checker.py
@@ -1,0 +1,3 @@
+def assert_log_correct(log_capture, logger_name, log_level, log_message):
+    """ Helper for testing correct log output. """
+    log_capture.check_present(('{}'.format(logger_name), '{}'.format(log_level), '{}'.format(log_message),))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,7 @@ coreapi==2.3.1
 django==1.11.11
 django-extensions==1.7.9
 django-filter==1.0.4
+django-ratelimit==1.1.0
 django-rest-swagger==2.2.0
 django-sortedm2m==1.5.0
 django-statici18n==1.7.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,4 +13,4 @@ pep8==1.7.0
 pytest==3.0.7
 pytest-django==3.1.2
 responses==0.5.1
-testfixtures==4.13.4
+testfixtures==6.2.0


### PR DESCRIPTION
[LEARNER-5925](https://openedx.atlassian.net/browse/LEARNER-5925) Adds django-ratelimit throttling to the credentials records endpoints.

Note:
At this time, we're not adding a higher rate limit for staff/superusers because these endpoints correspond to the share record and send record buttons, which staff should not be using much more frequently than regular users.