### PR TITLE
Prevent factory calls from getting included twice

### DIFF
--- a/credentials/templates/programs.html
+++ b/credentials/templates/programs.html
@@ -22,17 +22,18 @@
 
 {% block javascript %}
   {% render_bundle 'programs' 'js' %}
-    {% block program_record_factory %}
-      <script type="text/javascript">
-        ProgramRecordFactory('program-record', {
-          record: JSON.parse('{{record|escapejs}}'),
-          isPublic: {{ is_public|yesno:"true,false"}},
-          uuid: '{{uuid}}',
-          helpUrl: '{{records_help_url}}',
-        });
-      </script>
-    {% endblock %}
     {% if icons_template %}
       {% include icons_template %}
+    {% else %}
+      {% block program_record_factory %}
+        <script type="text/javascript">
+          ProgramRecordFactory('program-record', {
+            record: JSON.parse('{{record|escapejs}}'),
+            isPublic: {{ is_public|yesno:"true,false"}},
+            uuid: '{{uuid}}',
+            helpUrl: '{{records_help_url}}',
+          });
+        </script>
+    {% endblock %}
     {% endif %}
 {% endblock %}

--- a/credentials/templates/records.html
+++ b/credentials/templates/records.html
@@ -20,15 +20,18 @@
 
 {% block javascript %}
   {% render_bundle 'records' 'js' %}
-  <script type="text/javascript">
-    RecordsFactory('records', {
-      programs: JSON.parse('{{programs|escapejs}}'),
-      helpUrl: '{{records_help_url}}',
-      profileUrl: '{{profile_url}}',
-    });
-  </script>
     {% if icons_template %}
         {% include icons_template %}
+    {% else %}
+      {% block records_factory %}
+        <script type="text/javascript">
+        RecordsFactory('records', {
+          programs: JSON.parse('{{programs|escapejs}}'),
+          helpUrl: '{{records_help_url}}',
+          profileUrl: '{{profile_url}}',
+        });
+        </script>
+      {% endblock %}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Previously, in cases where a theme template exists, "default" blocks (without icons) for RecordsFactory and ProgramRecord factory were not getting overridden as expected when including the theme template. This meant that there were two calls for the factories on each page, rather than just the one for the themed template. This fixes that by only having the "default" blocks when the theme template doesn't exist. 

[LEARNER-5996](https://openedx.atlassian.net/browse/LEARNER-5996)