### PR TITLE
Fix records share analytics event name

### DIFF
--- a/credentials/static/components/ShareProgramRecordModal.jsx
+++ b/credentials/static/components/ShareProgramRecordModal.jsx
@@ -149,7 +149,7 @@ class ShareProgramRecordModal extends React.Component {
                   <Button
                     label={gettext('Copy Link')}
                     className={['btn-primary']}
-                    onClick={trackEvent('edx.bi.credential.program_record.share_url_copied', {
+                    onClick={trackEvent('edx.bi.credentials.program_record.share_url_copied', {
                       category: 'records',
                       'program-uuid': this.props.uuid,
                     })}


### PR DESCRIPTION
Fix the spelling of the edx.bi.credential.program_record.share_url_copied event to match the spelling of "credentials" in the other events.