### PR TITLE
Fix Records Waffle Flag Login Redirect

### DIFF
--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -44,12 +44,14 @@ logger = logging.getLogger(__name__)
 class RecordsEnabledMixin(object):
     """ Only allows view if records are enabled for the installation & site.
         Note that the API views are will still be active even if records is disabled.
-        You may want to disable records support in the LMS if you want to stop data being sent over. """
+        You may want to disable records support in the LMS if you want to stop data being sent over.
+        If the user is not logged in, we direct them to a login page first. """
     def dispatch(self, request, *args, **kwargs):
-        if not waffle.flag_is_active(request, WAFFLE_FLAG_RECORDS):
-            raise http.Http404()
-        if not request.site.siteconfiguration.records_enabled:
-            raise http.Http404()
+        if request.user.is_authenticated:
+            if not waffle.flag_is_active(request, WAFFLE_FLAG_RECORDS):
+                raise http.Http404()
+            if not request.site.siteconfiguration.records_enabled:
+                raise http.Http404()
         return super().dispatch(request, *args, **kwargs)
 
 


### PR DESCRIPTION
If a user is not logged in to credentials, redirect them to a login page before checking if the waffle flag is enabled.  This is because we don't know if the user has the flag enabled until they are logged in.

If the site has the "Enable Learner Records" option turned off in the site config, the user will still be redirected to a login page before hitting a 404.

This also doesn't affect the public records view.