### PR TITLE
Upgrade django to 1.11.15 for security update

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 analytics-python==1.2.9
 coreapi==2.3.1
-django==1.11.11
+django==1.11.15
 django-extensions==1.7.9
 django-filter==1.0.4
 django-ratelimit==1.1.0


### PR DESCRIPTION
## [LEARNER-6034](https://openedx.atlassian.net/browse/LEARNER-6034)


### Description
There is a vulnerability of phishing in django 1.11.11 announced by django community.To avoid it,upgrade current django version to 1.11.15 to overcome that vulnerability.

https://docs.djangoproject.com/en/2.0/releases/1.11.15/#cve-2018-14574-open-redirect-possibility-in-commonmiddleware