### PR TITLE
Track users who manually copy link instead of clicking button

### DIFF
--- a/credentials/static/components/ShareProgramRecordModal.jsx
+++ b/credentials/static/components/ShareProgramRecordModal.jsx
@@ -12,6 +12,7 @@ class ShareProgramRecordModal extends React.Component {
   constructor(props) {
     super(props);
 
+    this.checkUrlCopied = this.checkUrlCopied.bind(this);
     this.setProgramRecordUrl = this.setProgramRecordUrl.bind(this);
     this.setUrlError = this.setUrlError.bind(this);
     this.setUrlAsCopied = this.setUrlAsCopied.bind(this);
@@ -59,6 +60,17 @@ class ShareProgramRecordModal extends React.Component {
 
   setUrlError() {
     this.setState({ urlError: true });
+  }
+
+  checkUrlCopied() {
+    // if the full url is copied, behave as if the "Copy Link" button was clicked
+    if (window.getSelection().toString() === this.state.programRecordUrl) {
+      this.setUrlAsCopied(this.state.programRecordUrl, true);
+      trackEvent('edx.bi.credentials.program_record.share_url_copied', {
+        category: 'records',
+        'program-uuid': this.props.uuid,
+      });
+    }
   }
 
   // This logic is a bit complicated, so we separate it out
@@ -135,13 +147,15 @@ class ShareProgramRecordModal extends React.Component {
             {this.renderSwitchToSendParagraph()}
             {urlReturned &&
               <div>
-                <InputText
-                  value={programRecordUrl}
-                  name="program-record-share-url"
-                  className={['program-record-share-url']}
-                  label={<span className="sr-only">{gettext('Program Record URL')}</span>}
-                  disabled
-                />
+                <div onCopy={this.checkUrlCopied}>
+                  <InputText
+                    value={programRecordUrl}
+                    name="program-record-share-url"
+                    className={['program-record-share-url']}
+                    label={<span className="sr-only">{gettext('Program Record URL')}</span>}
+                    disabled
+                  />
+                </div>
                 <CopyToClipboard
                   text={programRecordUrl}
                   onCopy={this.setUrlAsCopied}

--- a/credentials/static/components/specs/ShareProgramRecordModal.test.jsx
+++ b/credentials/static/components/specs/ShareProgramRecordModal.test.jsx
@@ -62,7 +62,7 @@ describe('<ShareProgramRecordModal />', () => {
       });
     });
 
-    it('updates state if the url is copied to the clipboard', () => {
+    it('updates state if the url is copied to the clipboard via button', () => {
       expect(wrapper.state('urlCopied')).toBe(false);
 
       return promise.then(() => {
@@ -70,6 +70,28 @@ describe('<ShareProgramRecordModal />', () => {
         expect(wrapper.state('urlCopied')).toBe(false);
         wrapper.instance().setUrlAsCopied('text', 'result');
         expect(wrapper.state('urlCopied')).toBe(true);
+      });
+    });
+
+    it('updates state when the full url is manually copied to clipboard', () => {
+      window.getSelection = () => wrapper.state('programRecordUrl');
+      expect(wrapper.find('.modal-dialog').length).toBe(1);
+
+      return promise.then(() => {
+        wrapper.update();
+        wrapper.find('.modal-body .form-group input').simulate('copy');
+        expect(wrapper.state('urlCopied')).toBe(true);
+      });
+    });
+
+    it('does not update state when part of the url is manually copied to clipboard', () => {
+      window.getSelection = () => 'not_the_url';
+      expect(wrapper.find('.modal-dialog').length).toBe(1);
+
+      return promise.then(() => {
+        wrapper.update();
+        wrapper.find('.modal-body .form-group input').simulate('copy');
+        expect(wrapper.state('urlCopied')).toBe(false);
       });
     });
 

--- a/credentials/static/sass/views/_program-record.scss
+++ b/credentials/static/sass/views/_program-record.scss
@@ -88,6 +88,15 @@ $record-border-color: #C2C2C2;
     }
   }
 
+  .modal-body {
+    .form-group {
+      padding: 0;
+      .form-control {
+        -webkit-text-fill-color: inherit;
+      }
+    }
+  }
+
   // Override color to match edx-bootstrap
   .badge-success {
     background-color: #008100;
@@ -101,7 +110,8 @@ $record-border-color: #C2C2C2;
   }
 
   .program-record-share-url {
-    cursor: default;
+    cursor: text;
+    background-color: transparent;
   }
 
   .loading-wrapper {


### PR DESCRIPTION
[LEARNER-5895](https://openedx.atlassian.net/browse/LEARNER-5895)

The InputText field doesn't have an onCopy attribute, so I wrapped it in a div that does. That calls a function that checks what the highlighted text is (to make sure the full url was copied); if the full url was copied, it behaves the same way as if the copy to clipboard button was pressed (show alert and track event).
There doesn't appear to be a way to get a readonly mode with InputText field without disabling it, so I styled it to make it look "friendly".
Additionally, removed the horizontal padding on the url field.

<img width="579" alt="sharemodal" src="https://user-images.githubusercontent.com/13275224/43801965-805464e4-9a62-11e8-8fb4-0be695229f15.png">
