### PR TITLE
Change masquerade redirect to the admin page

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -390,7 +390,10 @@ RATELIMIT_VIEW = 'credentials.apps.records.views.rate_limited'
 # django-hijack settings
 HIJACK_AUTHORIZE_STAFF = True
 HIJACK_URL_ALLOWED_ATTRIBUTES = ('email', 'username',)
-HIJACK_LOGIN_REDIRECT_URL = '.'
+# Since we force reload pages when masquerading/hijacking, users don't
+# actually hit this page.  The admin endpoint just acts as a safe
+# follow through for all users to hit in the django-hijack redirect.
+HIJACK_LOGIN_REDIRECT_URL = '/admin/'
 
 # DJANGO DEBUG TOOLBAR CONFIGURATION
 # http://django-debug-toolbar.readthedocs.org/en/latest/installation.html


### PR DESCRIPTION
[LEARNER-6135](https://openedx.atlassian.net/browse/LEARNER-6135)

Django-hijack uses a follow through url that it always hits after masquerading, or releasing a user.  Since we reload the page to update the records view, users don't navigate to the follow through url, but it still has the potential to cause errors. Rerouting this to the admin page is safe, because all users, staff, and superusers will get a 200 from hitting either the admin dashboard or the admin login.  

**Sandbox**
Access the records page at https://credentials-masquerade-redirect.sandbox.edx.org/records/ .  

Users:
- Superuser: admin, admin@example.com
- Staff: credentials_service_user, no email
- User: verified, verified@example.com