### PR TITLE
Prevent superusers from masquerading as other superusers

### DIFF
--- a/credentials/apps/core/tests/factories.py
+++ b/credentials/apps/core/tests/factories.py
@@ -20,6 +20,7 @@ class UserFactory(django.DjangoModelFactory):
     full_name = Faker('name')
     email = Faker('safe_email')
     is_staff = False
+    is_superuser = False
     is_active = True
 
 

--- a/credentials/apps/records/utils.py
+++ b/credentials/apps/records/utils.py
@@ -1,6 +1,7 @@
 import logging
 import urllib
 
+from django.conf import settings
 from django.urls import reverse
 from edx_ace import Recipient, ace
 
@@ -58,3 +59,34 @@ def send_updated_emails_for_program(username, program_certificate):
                 },
             )
             ace.send(msg)
+
+
+def masquerading_authorized(masquerader, target):
+    """
+    Checks whether a user has the permissions to masquerade as the target user.
+
+    Overrides django-hijack's default authorization function to prevent
+    superusers from masquerading as other superusers.
+
+    By default only superusers are allowed to masquerade, unless
+    HIJACK_AUTHORIZE_STAFF is enabled in settings.
+
+    By default, staff are not able to masquerade as staff unless
+    HIJACK_AUTHORIZE_STAFF_TO_HIJACK_STAFF is enabled in settings.
+
+    Adapted from:
+    https://github.com/arteria/django-hijack/blob/4dd897761952adf387fb71822e3e76bc3d0deb51/hijack/helpers.py#L77
+    """
+    if target.is_superuser:
+        return False
+
+    if masquerader.is_superuser:
+        return True
+
+    if masquerader.is_staff and getattr(settings, 'HIJACK_AUTHORIZE_STAFF', False):
+        if target.is_staff and not getattr(settings, 'HIJACK_AUTHORIZE_STAFF_TO_HIJACK_STAFF', False):
+            return False
+
+        return True
+
+    return False

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -397,6 +397,7 @@ HIJACK_URL_ALLOWED_ATTRIBUTES = ('email', 'username',)
 # actually hit this page.  The admin endpoint just acts as a safe
 # follow through for all users to hit in the django-hijack redirect.
 HIJACK_LOGIN_REDIRECT_URL = '/admin/'
+HIJACK_AUTHORIZATION_CHECK = 'credentials.apps.records.utils.masquerading_authorized'
 
 # DJANGO DEBUG TOOLBAR CONFIGURATION
 # http://django-debug-toolbar.readthedocs.org/en/latest/installation.html


### PR DESCRIPTION
[LEARNER-6099](https://openedx.atlassian.net/browse/LEARNER-6099)

**Sandbox**
---
Sandbox at https://credentials-masquerade-permissions.sandbox.edx.org/records/

Superusers: superuser, superuser2
Staff: staff
Users: verified



Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [x] Request a review if desired
  - [x] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [x] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [x] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [x] Consider other browsers (e.g. Firefox)
    - [x] Check mobile view
    - [x] Consider accessibility (e.g. Run aXe on the page)
