### PR TITLE
Start using Pathway model

### DIFF
--- a/credentials/apps/catalog/management/commands/copy_catalog.py
+++ b/credentials/apps/catalog/management/commands/copy_catalog.py
@@ -60,6 +60,7 @@ class Command(BaseCommand):
     def fetch_pathways(site, client, page_size=None):
         next_page = 1
         while next_page:
+            # Switch to client.pathways.get(...) once discovery API endpoint is renamed
             pathways = client.credit_pathways.get(exclude_utm=1, page=next_page, page_size=page_size)
             for pathway in pathways['results']:
                 logger.info('Copying pathway "{}"'.format(pathway['name']))

--- a/credentials/apps/catalog/tests/test_commands.py
+++ b/credentials/apps/catalog/tests/test_commands.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from faker import Faker
 
-from credentials.apps.catalog.models import Course, CourseRun, CreditPathway, Organization, Pathway, Program
+from credentials.apps.catalog.models import Course, CourseRun, Organization, Pathway, Program
 from credentials.apps.catalog.tests.factories import OrganizationFactory, ProgramFactory
 from credentials.apps.core.tests.factories import SiteConfigurationFactory
 from credentials.apps.core.tests.mixins import SiteMixin
@@ -176,10 +176,8 @@ class CopyCatalogCommandTests(SiteMixin, TestCase):
         CourseRun.objects.get(key='course-v1:CakeX+Course1+Run2')
 
     def assertPathwaysSaved(self):
-        self.assertEqual(CreditPathway.objects.all().count(), len(self.PATHWAYS))  # Temporary: Remove with rename
         self.assertEqual(Pathway.objects.all().count(), len(self.PATHWAYS))
         for pathway in self.PATHWAYS:
-            CreditPathway.objects.get(uuid=pathway['uuid'])  # Temporary: Remove with rename
             Pathway.objects.get(uuid=pathway['uuid'])
 
     def assertFirstSaved(self):

--- a/credentials/apps/catalog/tests/test_utils.py
+++ b/credentials/apps/catalog/tests/test_utils.py
@@ -159,13 +159,7 @@ class ParseTests(TestCase):
         # We assume that programs are parsed separately from pathway data.
         parse_program(self.site, self.PROGRAM1_DATA)
 
-        # Temporary: Remove duplicate pathway parsing and testing with CreditPathway
-        credit_pathway, pathway = parse_pathway(self.site, self.PATHWAY1_DATA)
-        assert credit_pathway.uuid == self.PATHWAY1_DATA['uuid']
-        assert credit_pathway.name == self.PATHWAY1_DATA['name']
-        assert credit_pathway.email == self.PATHWAY1_DATA['email']
-        assert credit_pathway.org_name == self.PATHWAY1_DATA['org_name']
-        assert str(credit_pathway.programs.all()[0].uuid) == self.PROGRAM1_DATA['uuid']
+        pathway = parse_pathway(self.site, self.PATHWAY1_DATA)
         assert pathway.uuid == self.PATHWAY1_DATA['uuid']
         assert pathway.name == self.PATHWAY1_DATA['name']
         assert pathway.email == self.PATHWAY1_DATA['email']

--- a/credentials/apps/catalog/utils.py
+++ b/credentials/apps/catalog/utils.py
@@ -2,7 +2,7 @@
 
 from django.db import transaction
 
-from credentials.apps.catalog.models import Course, CourseRun, CreditPathway, Organization, Pathway, Program
+from credentials.apps.catalog.models import Course, CourseRun, Organization, Pathway, Program
 
 
 # Note: these parsing functions don't attempt to clear out old data that is no longer provided by Discovery.
@@ -90,24 +90,7 @@ def parse_program(site, data):
 def parse_pathway(site, data):
     """
     Assumes that the associated programs were parsed before this is run.
-
-    Duplicate pathway parsing is temporary.  Remove with CreditPathway.
     """
-    credit_pathway, _ = CreditPathway.objects.update_or_create(
-        uuid=data['uuid'],
-        site=site,
-        defaults={
-            'name': data['name'],
-            'email': data['email'],
-            'org_name': data['org_name'],
-        }
-    )
-
-    credit_pathway.programs.clear()
-    for program_data in data['programs']:
-        program = Program.objects.get(site=site, uuid=program_data['uuid'])
-        credit_pathway.programs.add(program)
-
     pathway, _ = Pathway.objects.update_or_create(
         uuid=data['uuid'],
         site=site,
@@ -123,4 +106,4 @@ def parse_pathway(site, data):
         program = Program.objects.get(site=site, uuid=program_data['uuid'])
         pathway.programs.add(program)
 
-    return credit_pathway, pathway
+    return pathway

--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -98,7 +98,7 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
         Issue a Program Certificate to the user.
 
         This function is being overriden to provide functionality for sending
-        an updated email to credit pathway partners
+        an updated email to pathway partners
 
         This action is idempotent. If the user has already earned the
         credential, a new one WILL NOT be issued. The existing credential
@@ -122,7 +122,7 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
             },
         )
 
-        # Send an updated email to a credit pathway org only if the user has previously sent one
+        # Send an updated email to a pathway org only if the user has previously sent one
         # This function call should be moved into some type of task queue
         # once credentials has that functionality
         if created:

--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -454,45 +454,45 @@ class ProgramRecordViewTests(SiteMixin, TestCase):
 
         self.assertEqual(program_data, expected)
 
-    def test_credit_pathway_data(self):
-        """ Test that the credit pathway data is returned successfully """
+    def test_pathway_data(self):
+        """ Test that the pathway data is returned successfully """
         response = self.client.get(reverse('records:private_programs', kwargs={'uuid': self.program.uuid.hex}))
-        credit_pathway_data = json.loads(response.context_data['record'])['credit_pathways']
+        pathway_data = json.loads(response.context_data['record'])['pathways']
 
         expected = [{'name': self.pathway.name,
                      'id': self.pathway.id,
                      'status': '',
                      'is_active': True}]
 
-        self.assertEqual(credit_pathway_data, expected)
+        self.assertEqual(pathway_data, expected)
 
-    def test_credit_pathway_no_email(self):
-        """ Test that a credit pathway data without an email is inactive """
+    def test_pathway_no_email(self):
+        """ Test that a pathway without an email is inactive """
         self.pathway.email = ''
         self.pathway.save()
         response = self.client.get(reverse('records:private_programs', kwargs={'uuid': self.program.uuid.hex}))
-        credit_pathway_data = json.loads(response.context_data['record'])['credit_pathways']
+        pathway_data = json.loads(response.context_data['record'])['pathways']
 
         expected = [{'name': self.pathway.name,
                      'id': self.pathway.id,
                      'status': '',
                      'is_active': False}]
 
-        self.assertEqual(credit_pathway_data, expected)
+        self.assertEqual(pathway_data, expected)
 
-    def test_sent_credit_pathway_status(self):
-        """ Test that a credit pathway that has already been sent includes a pathway """
+    def test_sent_pathway_status(self):
+        """ Test that a user credit pathway pathway that has already been sent includes a pathway """
         UserCreditPathwayFactory(pathway=self.pathway, user=self.user)
 
         response = self.client.get(reverse('records:private_programs', kwargs={'uuid': self.program.uuid.hex}))
-        credit_pathway_data = json.loads(response.context_data['record'])['credit_pathways']
+        pathway_data = json.loads(response.context_data['record'])['pathways']
 
         expected = [{'name': self.pathway.name,
                      'id': self.pathway.id,
                      'status': 'sent',
                      'is_active': True}]
 
-        self.assertEqual(credit_pathway_data, expected)
+        self.assertEqual(pathway_data, expected)
 
     def test_xss(self):
         """ Verify that the view protects against xss in translations. """
@@ -794,7 +794,7 @@ class RecordsThrottlingTests(SiteMixin, TestCase):
         for _ in range(attempts):
             response = self.post(url, json_data)
             if endpoint == 'send_program':
-                # Delete credit pathway after post to enable resending email
+                # Delete user credit pathway after post to enable resending email
                 UserCreditPathway.objects.all().delete()
 
             self.assertEqual(response.status_code, 200)

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -78,16 +78,16 @@ def get_record_data(user, program_uuid, site, platform_name=None):
         program_course_runs = program.course_runs.all()
         program_course_runs_set = frozenset(program_course_runs)
 
-        # Get all credit pathway organizations and their statuses
+        # Get all pathway organizations and their statuses
         # Use program.pathways once Pathway has that related name
-        program_credit_pathways = program.pathway_set.all()
-        program_credit_pathways_set = frozenset(program_credit_pathways)
+        program_pathways = program.pathway_set.all()
+        program_pathways_set = frozenset(program_pathways)
         user_credit_pathways = UserCreditPathway.objects.select_related('pathway').filter(
-            user=user, pathway__in=program_credit_pathways_set).all()
+            user=user, pathway__in=program_pathways_set).all()
         user_credit_pathways_dict = {user_pathway.pathway:
                                      user_pathway.status for user_pathway in user_credit_pathways}
-        credit_pathways = [(pathway, user_credit_pathways_dict.setdefault(pathway, ''))
-                           for pathway in program_credit_pathways]
+        pathways = [(pathway, user_credit_pathways_dict.setdefault(pathway, ''))
+                    for pathway in program_pathways]
 
         # Find program credential if it exists (indicates if user has completed this program)
         program_credential_query = UserCredential.objects.filter(
@@ -153,11 +153,11 @@ def get_record_data(user, program_uuid, site, platform_name=None):
                         'last_updated': last_updated.isoformat(),
                         'school': ', '.join(program.authoring_organizations.values_list('name', flat=True))}
 
-        credit_pathway_data = [{'name': credit_pathway[0].name,
-                                'id': credit_pathway[0].id,
-                                'status': credit_pathway[1],
-                                'is_active': bool(credit_pathway[0].email)}
-                               for credit_pathway in credit_pathways]
+        pathway_data = [{'name': pathway[0].name,
+                         'id': pathway[0].id,
+                         'status': pathway[1],
+                         'is_active': bool(pathway[0].email)}
+                        for pathway in pathways]
 
         # Add course-run data to the response in the order that is maintained by the Program's sorted field
         course_data = []
@@ -195,7 +195,7 @@ def get_record_data(user, program_uuid, site, platform_name=None):
                 'program': program_data,
                 'platform_name': platform_name,
                 'grades': course_data,
-                'credit_pathways': credit_pathway_data, }
+                'pathways': pathway_data, }
 
 
 class RecordsView(LoginRequiredMixin, RecordsEnabledMixin, TemplateView, ThemeViewMixin):

--- a/credentials/static/components/ProgramRecord.jsx
+++ b/credentials/static/components/ProgramRecord.jsx
@@ -33,7 +33,7 @@ class ProgramRecord extends React.Component {
     this.closeSendRecordSuccessAlert = this.closeSendRecordSuccessAlert.bind(this);
     this.closeSendRecordLoadingAlert = this.closeSendRecordLoadingAlert.bind(this);
     this.creditPathways = this.parseCreditPathways();
-    this.showSendRecordButton = this.props.credit_pathways.length > 0;
+    this.showSendRecordButton = this.props.pathways.length > 0;
 
     this.state = {
       shareModelOpen: false,
@@ -149,8 +149,8 @@ class ProgramRecord extends React.Component {
   parseCreditPathways() {
     const creditPathways = {};
 
-    for (let i = 0; i < this.props.credit_pathways.length; i += 1) {
-      const pathway = this.props.credit_pathways[i];
+    for (let i = 0; i < this.props.pathways.length; i += 1) {
+      const pathway = this.props.pathways[i];
       const sent = (pathway.status === 'sent');
 
       creditPathways[pathway.name] = {
@@ -416,7 +416,7 @@ class ProgramRecord extends React.Component {
             // For some reason they were not properly creating copies
             creditPathways={JSON.parse(JSON.stringify(this.creditPathways))}
             // Passing both a list and an object so that we can maintain pathway ordering
-            creditPathwaysList={this.props.credit_pathways}
+            creditPathwaysList={this.props.pathways}
           />
         }
         {shareModelOpen &&
@@ -449,7 +449,7 @@ ProgramRecord.propTypes = {
     last_updated: PropTypes.string,
   }).isRequired,
   grades: PropTypes.arrayOf(PropTypes.object).isRequired,
-  credit_pathways: PropTypes.arrayOf(PropTypes.object),
+  pathways: PropTypes.arrayOf(PropTypes.object),
   isPublic: PropTypes.bool,
   icons: PropTypes.shape(),
   uuid: PropTypes.string.isRequired,
@@ -459,7 +459,7 @@ ProgramRecord.propTypes = {
 };
 
 ProgramRecord.defaultProps = {
-  credit_pathways: [],
+  pathways: [],
   isPublic: true,
   icons: {},
   loadModalsAsChildren: true,

--- a/credentials/static/components/specs/ProgramRecord.test.jsx
+++ b/credentials/static/components/specs/ProgramRecord.test.jsx
@@ -49,7 +49,7 @@ const defaultProps = {
       school: 'TestX',
     },
   ],
-  credit_pathways: [
+  pathways: [
     {
       name: 'testX',
       id: 1,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ This repository contains the edX Credentials Service, used as the backend to sup
    credentials_admin
    configuring_certificates
    program_records
-   credit_pathways
+   pathways
    analytics
    credentials_api
    edx_extensions

--- a/docs/pathways.rst
+++ b/docs/pathways.rst
@@ -1,10 +1,12 @@
-Credit Pathways
-===============
-Credit pathways represent channels where learners can send their program records to institutions for credit.
+Pathways
+========
+Pathways represent channels where learners can send their program records to institutions for credit or other
+reasons.  Pathways can be either professional, or for credit, but they are mostly used as credit pathways in
+credentials.
 
 Creation
 --------
-Credit pathways get created in the course-discovery_ admin.
+Pathways get created in the course-discovery_ admin.
 Credentials receives these pathways by calling the ``copy_catalog`` management command.
 
 .. _course-discovery: https://github.com/edx/course-discovery

--- a/docs/program_records.rst
+++ b/docs/program_records.rst
@@ -58,6 +58,6 @@ A learner can also choose to send the record to a site partner, to receive credi
 Note that this merely sends an email to the partner so they can see the record.
 Each partner will have their own process for initiating or processing a credit request, of which viewing a learnerʼs record is one small part.
 
-Read the :doc:`credit pathways <credit_pathways>` documentation for more information on how to enable and configure requesting credit.
+Read the :doc:`pathways <pathways>` documentation for more information on how to enable and configure requesting credit.
 
 If no credit pathways are enabled for a given program, the ``Send Learner Record`` button will not appear on that programʼs records.


### PR DESCRIPTION
Replace all backend usages of CreditPathway with Pathway in preparation for removing CreditPathway.

Currently does not change the language in the ProgramRecord or SendLearnerRecordModal files, since it was my understanding that those components will always be handling pathways that are associated with credit institutions.  Happy to rename if we decide we do want that updated.  Also, this PR does not include any updates to the dev docs, and I had a question about the updates that will go there.

Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
