### PR TITLE
Filter program certs by visible_date

### DIFF
--- a/credentials/apps/api/v2/filters.py
+++ b/credentials/apps/api/v2/filters.py
@@ -3,6 +3,7 @@ from django.db.models import Q
 
 from credentials.apps.catalog.models import Program
 from credentials.apps.credentials.models import UserCredential
+from credentials.apps.credentials.utils import filter_visible
 
 
 class ProgramRelatedFilter(django_filters.Filter):
@@ -22,6 +23,10 @@ class CredentialTypeFilter(django_filters.Filter):
         return qs
 
 
+def handle_only_visible(qs, _name, value):
+    return filter_visible(qs) if value else qs
+
+
 class UserCredentialFilter(django_filters.FilterSet):
     program_uuid = ProgramRelatedFilter(
         label='UUID of the program for which the credential was awarded'
@@ -34,6 +39,7 @@ class UserCredentialFilter(django_filters.FilterSet):
         label='Status of the credential'
     )
     username = django_filters.CharFilter(label='Username of the recipient of the credential')
+    only_visible = django_filters.BooleanFilter(method=handle_only_visible)
 
     class Meta:
         model = UserCredential

--- a/credentials/apps/credentials/tests/test_utils.py
+++ b/credentials/apps/credentials/tests/test_utils.py
@@ -1,15 +1,16 @@
+import datetime
 import ddt
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from credentials.apps.credentials.utils import validate_duplicate_attributes
+from credentials.apps.credentials.utils import datetime_from_visible_date, validate_duplicate_attributes
 
 User = get_user_model()
 
 
 @ddt.ddt
-class ValidateDuplicateAttributesTests(TestCase):
-    """ Tests for Validate the attributes method """
+class CredentialsUtilsTests(TestCase):
+    """ Tests for credentials.utils methods """
 
     def test_with_non_duplicate_attributes(self):
         """ Verify that the function will return True if no duplicated attributes found."""
@@ -28,3 +29,11 @@ class ValidateDuplicateAttributesTests(TestCase):
         ]
 
         self.assertFalse(validate_duplicate_attributes(attributes))
+
+    def test_datetime_from_visible_date(self):
+        """ Verify that we convert LMS dates correctly. """
+        self.assertIsNone(datetime_from_visible_date(''))
+        self.assertIsNone(datetime_from_visible_date('2018-07-31'))
+        self.assertIsNone(datetime_from_visible_date('2018-07-31T09:32:46+00:00'))  # should be Z for timezone
+        self.assertEqual(datetime_from_visible_date('2018-07-31T09:32:46Z'),
+                         datetime.datetime(2018, 7, 31, 9, 32, 46, tzinfo=datetime.timezone.utc))

--- a/credentials/apps/credentials/utils.py
+++ b/credentials/apps/credentials/utils.py
@@ -1,4 +1,14 @@
+import datetime
+import logging
 from itertools import groupby
+
+from django.db.models import Q
+
+from credentials.apps.credentials.models import UserCredentialAttribute
+
+log = logging.getLogger(__name__)
+
+VISIBLE_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 
 def to_language(locale):
@@ -28,3 +38,54 @@ def validate_duplicate_attributes(attributes):
         if len(list(group)) > 1:
             return False
     return True
+
+
+def datetime_from_visible_date(date):
+    """ Turn a string version of a datetime, provided to us by the LMS in a particular format it uses for
+        visible_date attributes, and turn it into a datetime object. """
+    try:
+        parsed = datetime.datetime.strptime(date, VISIBLE_DATE_FORMAT)
+        # The timezone is always UTC (as indicated by the Z). It looks like in python3.7, we could
+        # just use %z instead of replacing the tzinfo with a UTC value.
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    except ValueError as e:
+        log.exception('%s', e)
+        return None
+
+
+def filter_visible(qs):
+    """ Filters a UserCredentials queryset by excluding credentials that aren't supposed to be visible yet. """
+    # The visible_date attribute holds a string value, not a datetime one. But we can compare as a string
+    # because the format is so strict - it will still lexically compare as less/greater-than.
+    nowstr = datetime.datetime.now(datetime.timezone.utc).strftime(VISIBLE_DATE_FORMAT)
+    return qs.filter(
+        Q(attributes__name='visible_date', attributes__value__lte=nowstr) | ~Q(attributes__name='visible_date')
+    )
+
+
+def get_credential_visible_dates(user_credentials):
+    """
+    Calculates visible date for a collection of UserCredentials.
+    Returns a dictionary of {UserCredential: datetime}.
+    Guaranteed to return a datetime object for each credential.
+    """
+
+    visible_dates = UserCredentialAttribute.objects.prefetch_related('user_credential__credential').filter(
+        user_credential__in=user_credentials, name='visible_date')
+
+    visible_date_dict = {
+        visible_date.user_credential: datetime_from_visible_date(visible_date.value)
+        for visible_date in visible_dates
+    }
+
+    for user_credential in user_credentials:
+        current = visible_date_dict.get(user_credential)
+        if current is None:
+            visible_date_dict[user_credential] = user_credential.created
+
+    return visible_date_dict
+
+
+def get_credential_visible_date(user_credential):
+    """ Simpler, one-credential version of get_credential_visible_dates. """
+    return get_credential_visible_dates([user_credential])[user_credential]

--- a/credentials/templates/credentials/programs/base.html
+++ b/credentials/templates/credentials/programs/base.html
@@ -101,7 +101,7 @@
             <span class="copy-micro emphasized">
               {# Translators: This phrase appears on certificates to show the issue date #}
               {% trans "Issued {month} {year}" as tmsg %}
-              {% interpolate_html tmsg month=user_credential.modified|month year=user_credential.modified|date:"Y" as tmsg %}
+              {% interpolate_html tmsg month=issue_date|month year=issue_date|date:"Y" as tmsg %}
               {{ tmsg | capfirst }}
             </span>
           </li>


### PR DESCRIPTION
Whenever we show a program credential, make sure that it is actually supposed to be shown. We rely on the visible_date field for program credentials to be actually populated by the LMS for this feature.

https://openedx.atlassian.net/browse/LEARNER-6263

Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
