### PR TITLE
ARCH-262: Reverts addition of JwtAuthCookieMiddleware

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -87,7 +87,6 @@ MIDDLEWARE_CLASSES = (
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
-    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 )
 
 ROOT_URLCONF = 'credentials.urls'


### PR DESCRIPTION
When JWT cookies are required, there will be some work needed to make this work.  
See "[ARCH-266: Backend: Enable JWT Cookies in remaining IDAs.](https://openedx.atlassian.net/browse/ARCH-266)"