### PR TITLE
Remove usages of OAUTH2_PROVIDER_URL, add BACKEND_SERVICE_EDX_OAUTH2_…

### DIFF
--- a/credentials/apps/api/authentication.py
+++ b/credentials/apps/api/authentication.py
@@ -77,4 +77,4 @@ class BearerAuthentication(BaseBearerAuthentication):
     """
     def get_user_info_url(self):
         """ Returns the URL, hosted by the OAuth2 provider, from which user information can be pulled. """
-        return '{base}/user_info/'.format(base=settings.OAUTH2_PROVIDER_URL)
+        return '{base}/user_info/'.format(base=settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL)

--- a/credentials/apps/core/models.py
+++ b/credentials/apps/core/models.py
@@ -135,7 +135,7 @@ class SiteConfiguration(models.Model):
 
     @property
     def oauth2_provider_url(self):
-        return settings.OAUTH2_PROVIDER_URL
+        return settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL
 
     @property
     def oauth2_client_id(self):

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -307,7 +307,6 @@ AUTHENTICATION_BACKENDS = (
 ENABLE_AUTO_AUTH = False
 AUTO_AUTH_USERNAME_PREFIX = 'auto_auth_'
 
-OAUTH2_PROVIDER_URL = None
 OAUTH_ID_TOKEN_EXPIRATION = 60
 
 SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
@@ -334,10 +333,13 @@ SOCIAL_AUTH_PIPELINE = (
 # Set these to the correct values for your OAuth2 provider (e.g., devstack)
 SOCIAL_AUTH_EDX_OAUTH2_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = 'replace-me'
+SOCIAL_AUTH_EDX_OAUTH2_ISSUER = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = 'replace-me'
+SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = 'replace-me'
 BACKEND_SERVICE_EDX_OAUTH2_KEY = 'replace-me'
 BACKEND_SERVICE_EDX_OAUTH2_SECRET = 'replace-me'
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = 'replace-me'
 
 # Request the user's permissions in the ID token
 EXTRA_SCOPE = ['permissions']

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -45,9 +45,6 @@ MEDIA_URL = os.environ.get('MEDIA_URL', '/media/')
 STATICFILES_STORAGE = os.environ.get('STATICFILES_STORAGE', 'django.contrib.staticfiles.storage.StaticFilesStorage')
 STATIC_URL = os.environ.get('STATIC_URL', '/static/')
 
-# Generic OAuth2 variables irrespective of SSO/backend service key types.
-OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
-
 # OAuth2 variables specific to social-auth/SSO login use case.
 SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'credentials-sso-key')
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'credentials-sso-secret')
@@ -61,6 +58,9 @@ SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = os.environ.get(
 # OAuth2 variables specific to backend service API calls.
 BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY', 'credentials-backend-service-key')
 BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'credentials-backend-service-secret')
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = os.environ.get(
+    'BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL', 'http://edx.devstack.lms:18000/oauth2',
+)
 
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = str2bool(os.environ.get('SOCIAL_AUTH_REDIRECT_IS_HTTPS', False))
 

--- a/credentials/settings/local.py
+++ b/credentials/settings/local.py
@@ -37,13 +37,9 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # AUTHENTICATION
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 
-# Generic OAuth2 variables irrespective of SSO/backend service key types.
-OAUTH2_PROVIDER_URL = 'http://localhost:18000/oauth2'
-
 # OAuth2 variables specific to social-auth/SSO login use case.
 SOCIAL_AUTH_EDX_OAUTH2_KEY = 'credentials-sso-key'
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = 'credentials-sso-secret'
-SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = OAUTH2_PROVIDER_URL
 
 # OAuth2 variables specific to backend service API calls.
 BACKEND_SERVICE_EDX_OAUTH2_KEY = 'credentials-backend-service-key'
@@ -71,6 +67,6 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 JWT_AUTH.update({
     'JWT_ALGORITHM': 'HS256',
     'JWT_SECRET_KEY': SOCIAL_AUTH_EDX_OAUTH2_SECRET,
-    'JWT_ISSUER': OAUTH2_PROVIDER_URL,
+    'JWT_ISSUER': SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT,
     'JWT_AUDIENCE': SOCIAL_AUTH_EDX_OAUTH2_KEY,
 })

--- a/credentials/settings/test.py
+++ b/credentials/settings/test.py
@@ -38,11 +38,11 @@ DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 MEDIA_ROOT = TEST_ROOT / 'uploads'
 MEDIA_URL = '/static/uploads/'
 
-OAUTH2_PROVIDER_URL = 'https://test-provider/oauth2'
-SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = OAUTH2_PROVIDER_URL
+SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'https://test-provider'
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = 'https://test-provider/oauth2'
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': SOCIAL_AUTH_EDX_OAUTH2_SECRET,
-    'JWT_ISSUER': OAUTH2_PROVIDER_URL,
+    'JWT_ISSUER': 'https://test-provider/oauth2',
     'JWT_AUDIENCE': SOCIAL_AUTH_EDX_OAUTH2_KEY,
 })


### PR DESCRIPTION
…PROVIDER_URL

Replace with either of these alternatives, depending on how its used:

* BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL
* SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT

Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
