### PR TITLE
Add username replacement API

### DIFF
--- a/credentials/apps/api/v2/permissions.py
+++ b/credentials/apps/api/v2/permissions.py
@@ -1,6 +1,7 @@
 """
 Custom permissions classes for use with DRF.
 """
+from django.conf import settings
 from rest_framework import permissions
 
 
@@ -40,3 +41,11 @@ class UserCredentialPermissions(permissions.DjangoModelPermissions):
             return default or (request.user.username.lower() == filtered_username)
 
         return default
+
+
+class CanReplaceUsername(permissions.BasePermission):
+    """
+    Grants access to the Username Replacement API for the service user.
+    """
+    def has_permission(self, request, view):
+        return request.user.username == getattr(settings, "USERNAME_REPLACEMENT_WORKER")

--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -2,12 +2,14 @@ import json
 from decimal import Decimal
 
 import ddt
+import mock
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.renderers import JSONRenderer
 from rest_framework.test import APIRequestFactory, APITestCase
 
+from credentials.apps.api.tests.mixins import JwtMixin
 from credentials.apps.api.v2.serializers import (UserCredentialAttributeSerializer, UserCredentialSerializer,
                                                  UserGradeSerializer)
 from credentials.apps.api.v2.views import CredentialRateThrottle
@@ -517,3 +519,86 @@ class ThrottlingTests(TestCase):
         """ Verify that throttling is configured for each scope. """
         self.throttle.scope = scope
         self.assertIsNotNone(self.throttle.parse_rate(self.throttle.get_rate()))
+
+
+@ddt.ddt
+@mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
+class UsernameReplacementViewTests(JwtMixin, APITestCase):
+    """ Tests UsernameReplacementView """
+    SERVICE_USERNAME = 'test_replace_username_service_worker'
+
+    def setUp(self):
+        super(UsernameReplacementViewTests, self).setUp()
+        self.service_user = UserFactory(username=self.SERVICE_USERNAME)
+        self.url = reverse("api:v2:replace_usernames")
+
+    def build_jwt_headers(self, user):
+        """
+        Helper function for creating headers for the JWT authentication.
+        """
+        jwt_payload = self.default_payload(user)
+        token = self.generate_token(jwt_payload)
+        headers = {'HTTP_AUTHORIZATION': 'JWT ' + token.decode()}
+        return headers
+
+    def call_api(self, user, data):
+        """ Helper function to call API with data """
+        data = json.dumps(data)
+        headers = self.build_jwt_headers(user)
+        return self.client.post(self.url, data, **headers, content_type=JSON_CONTENT_TYPE)
+
+    def test_auth(self):
+        """ Verify the endpoint only works with the service worker """
+        data = {
+            "username_mappings": [
+                {"test_username_1": "test_new_username_1"},
+                {"test_username_2": "test_new_username_2"}
+            ]
+        }
+
+        # Test unauthenticated
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 401)
+
+        # Test non-service worker
+        random_user = UserFactory()
+        response = self.call_api(random_user, data)
+        self.assertEqual(response.status_code, 403)
+
+        # Test service worker
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 200)
+
+    @ddt.data(
+        [{}, {}],
+        {},
+        [{"test_key": "test_value", "test_key_2": "test_value_2"}]
+    )
+    def test_bad_schema(self, mapping_data):
+        """ Verify the endpoint rejects bad data schema """
+        data = {
+            "username_mappings": mapping_data
+        }
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_existing_and_non_existing_users(self):
+        """
+        Tests a mix of existing and non existing users. Users that don't exist
+        in this service are also treated as a success because no work needs to
+        be done changing their username.
+        """
+        random_users = [UserFactory() for _ in range(5)]
+        fake_usernames = ["myname_" + str(x) for x in range(5)]
+        existing_users = [{user.username: user.username + '_new'} for user in random_users]
+        non_existing_users = [{username: username + '_new'} for username in fake_usernames]
+        data = {
+            "username_mappings": existing_users + non_existing_users
+        }
+        expected_response = {
+            'failed_replacements': [],
+            'successful_replacements': existing_users + non_existing_users
+        }
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, expected_response)

--- a/credentials/apps/api/v2/urls.py
+++ b/credentials/apps/api/v2/urls.py
@@ -1,11 +1,15 @@
+from django.conf.urls import url
 from rest_framework.routers import DefaultRouter
 
 from credentials.apps.api.v2 import views
+
+urlpatterns = [
+    url(r'^replace_usernames/$', views.UsernameReplacementView.as_view(), name="replace_usernames")
+]
 
 router = DefaultRouter()  # pylint: disable=invalid-name
 # URLs can not have hyphen as it is not currently supported by slumber
 # as mentioned https://github.com/samgiles/slumber/issues/44
 router.register(r'credentials', views.CredentialViewSet, base_name='credentials')
 router.register(r'grades', views.GradeViewSet, base_name='grades')
-
-urlpatterns = router.urls
+urlpatterns += router.urls

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -1,14 +1,17 @@
 import logging
 
+from django.apps import apps
+from django.db import transaction
 from django.db.models import Q
-from rest_framework import mixins, viewsets
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.exceptions import Throttled
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
-from rest_framework.views import exception_handler
+from rest_framework.views import APIView, exception_handler
 
 from credentials.apps.api.v2.filters import UserCredentialFilter
-from credentials.apps.api.v2.permissions import UserCredentialPermissions
+from credentials.apps.api.v2.permissions import CanReplaceUsername, UserCredentialPermissions
 from credentials.apps.api.v2.serializers import (UserCredentialCreationSerializer, UserCredentialSerializer,
                                                  UserGradeSerializer)
 from credentials.apps.credentials.models import UserCredential
@@ -145,3 +148,139 @@ class GradeViewSet(mixins.CreateModelMixin,
     def update(self, request, *args, **kwargs):  # pylint: disable=useless-super-delegation
         """ Update a grade. """
         return super(GradeViewSet, self).update(request, *args, **kwargs)
+
+
+class UsernameReplacementView(APIView):
+    """
+    WARNING: This API is only meant to be used as part of a larger job that
+    updates usernames across all services. DO NOT run this alone or users will
+    not match across the system and things will be broken. This API should be
+    called from the LMS endpoint which verifies uniqueness of the username
+    first.
+
+    API will recieve a list of current usernames and their new username.
+    """
+
+    authentication_classes = (JwtAuthentication, )
+    permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
+
+    def post(self, request):
+        """
+        **POST Parameters**
+
+        A POST request must include the following parameter.
+
+        * username_mappings: Required. A list of objects that map the current username (key)
+          to the new username (value)
+            {
+                "username_mappings": [
+                    {"current_username_1": "new_username_1"},
+                    {"current_username_2": "new_username_2"}
+                ]
+            }
+
+        **POST Response Values**
+
+        As long as data validation passes, the request will return a 200 with a new mapping
+        of old usernames (key) to new username (value)
+
+        {
+            "successful_replacements": [
+                {"old_username_1": "new_username_1"}
+            ],
+            "failed_replacements": [
+                {"old_username_2": "new_username_2"}
+            ]
+        }
+        """
+        # (model_name, column_name)
+        MODELS_WITH_USERNAME = (
+            ('core.user', 'username'),
+            ('credentials.usercredential', 'username'),
+            ('records.usergrade', 'username'),
+        )
+        username_mappings = request.data.get("username_mappings")
+
+        replacement_locations = self._load_models(MODELS_WITH_USERNAME)
+
+        if not self._has_valid_schema(username_mappings):
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        successful_replacements, failed_replacements = [], []
+
+        for username_pair in username_mappings:
+            current_username = list(username_pair.keys())[0]
+            new_username = list(username_pair.values())[0]
+            successfully_replaced = self._replace_username_for_all_models(
+                current_username,
+                new_username,
+                replacement_locations
+            )
+            if successfully_replaced:
+                successful_replacements.append({current_username: new_username})
+            else:
+                failed_replacements.append({current_username: new_username})
+        return Response(
+            status=status.HTTP_200_OK,
+            data={
+                "successful_replacements": successful_replacements,
+                "failed_replacements": failed_replacements
+            }
+        )
+
+    def _load_models(self, models_with_fields):
+        """ Takes tuples that contain a model path and returns the list with a loaded version of the model """
+        try:
+            replacement_locations = [(apps.get_model(model), column) for (model, column) in models_with_fields]
+        except LookupError:
+            log.exception("Unable to load models for username replacement")
+            raise
+        return replacement_locations
+
+    def _has_valid_schema(self, post_data):
+        """ Verifies the data is a list of objects with a single key:value pair """
+        if not isinstance(post_data, list):
+            return False
+        for obj in post_data:
+            if not (isinstance(obj, dict) and len(obj) == 1):
+                return False
+        return True
+
+    def _replace_username_for_all_models(self, current_username, new_username, replacement_locations):
+        """
+        Replaces current_username with new_username for all (model, column) pairs in replacement locations.
+        Returns if it was successful or not. Usernames that don't exist in this service will be treated as
+        a success because no work needs to be done changing their username.
+        """
+        try:
+            with transaction.atomic():
+                num_rows_changed = 0
+                for (model, column) in replacement_locations:
+                    num_rows_changed += model.objects.filter(
+                        **{column: current_username}
+                    ).update(
+                        **{column: new_username}
+                    )
+        except Exception as exc:  # pylint: disable=broad-except
+            log.exception(
+                "Unable to change username from %s to %s. Failed on table %s because %s",
+                current_username,
+                new_username,
+                model.__class__.__name__,
+                exc
+            )
+            return False
+        if num_rows_changed == 0:
+            log.info(
+                "Unable to change username from %s to %s because %s doesn't exist.",
+                current_username,
+                new_username,
+                current_username,
+            )
+        else:
+            log.info(
+                "Successfully changed username from %s to %s.",
+                current_username,
+                new_username,
+            )
+        return True

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -431,3 +431,5 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
         'debug_toolbar.panels.redirects.RedirectsPanel',
     ]
 # END DJANGO DEBUG TOOLBAR CONFIGURATION
+
+USERNAME_REPLACEMENT_WORKER = "replace with valid username"


### PR DESCRIPTION
New API replaces all copies of username in this service with a new
username. Requires user be in a username_replacement_admin group. Should
only be ran as a larger job to update usernames across all services,
otherwise the system will be left in a broken state for those users.

Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
