### PR TITLE
LEARNER-7043: Encode filename to download record

### DIFF
--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -964,6 +964,25 @@ class ProgramRecordCsvViewTests(SiteMixin, TestCase):
         for header in headers:
             self.assertIn(header, csv_headers)
 
+    @patch('credentials.apps.records.views.SegmentClient', autospec=True)
+    def test_filename(self, segment_client):  # pylint: disable=unused-argument
+        """
+        Verify that the filename in response Content-Disposition is utf-8 encoded
+        """
+        filename = '{username}_{program_name}_grades'.format(
+            username=self.user.username,
+            program_name=self.program_cert_record.program.title
+        )
+        filename = filename.replace(' ', '_').lower().encode('utf-8')
+        expected = 'attachment; filename="{filename}.csv"'.format(filename=filename)
+
+        response = self.client.get(
+            reverse('records:program_record_csv', kwargs={'uuid': self.program_cert_record.uuid.hex})
+        )
+        actual = response['Content-Disposition']
+
+        self.assertEqual(actual, expected)
+
 
 @ddt.ddt
 class MasqueradeBannerFactoryTests(SiteMixin, TestCase):

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -551,7 +551,7 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
         writer.writeheader()
         writer.writerows(record['grades'])
         string_io.seek(0)
-        filename = '{username}_{program_name}_grades.csv'.format(
+        filename = '{username}_{program_name}_grades'.format(
             username=record['learner']['username'],
             program_name=record['program']['name']
         )
@@ -564,7 +564,8 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
             properties=properties,
             segment_client=segment_client,
         )
-        response['Content-Disposition'] = 'attachment; filename={filename}'.format(
-            filename=filename.replace(' ', '_').lower()
+        filename = filename.replace(' ', '_').lower().encode('utf-8')
+        response['Content-Disposition'] = 'attachment; filename="{filename}.csv"'.format(
+            filename=filename
         )
         return response


### PR DESCRIPTION
[LEARNER-7043](https://openedx.atlassian.net/browse/LEARNER-7043)

Learners enrolled in some programs i.e **Gestión Pública para el Desarrollo** are getting **_internal server error_**. The issue is in the filename. If the filename contains special characters that do not lie in ordinal range(128) of ascii it gives internal server error. The filename is created by following the pattern username_program_name_grades.csv. This filename becomes a part of Content Disposition and the error occurs in [gunicorn package](https://github.com/benoitc/gunicorn/blob/master/gunicorn/http/wsgi.py#L318) as it uses ascii
#### Description
For a fix I changed the code to encode the file in 'utf-8' before sending it to response['Content-Disposition']
#### Tests
- I have setup gunicorn on local system and tested the changes
- Verified on chrome and firefox