### PR TITLE
PROD-189 send emails for program if records_enabled is true

### DIFF
--- a/credentials/apps/api/accreditors.py
+++ b/credentials/apps/api/accreditors.py
@@ -30,10 +30,11 @@ class Accreditor(object):
             else:
                 self.credential_type_issuer_map[credential_type] = issuer
 
-    def issue_credential(self, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
+    def issue_credential(self, site, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
         """Issues a credential.
 
         Arguments:
+            site (Site Object): The current site
             credential (AbstractCredential): Type of credential to issue.
             username (str): Username of the recipient.
             status (str): Status of credential.
@@ -54,4 +55,4 @@ class Accreditor(object):
                 )
             )
 
-        return credential_issuer.issue_credential(credential, username, status, attributes)
+        return credential_issuer.issue_credential(site, credential, username, status, attributes)

--- a/credentials/apps/api/tests/test_accreditors.py
+++ b/credentials/apps/api/tests/test_accreditors.py
@@ -8,6 +8,7 @@ from testfixtures import LogCapture
 
 from credentials.apps.api.accreditors import Accreditor
 from credentials.apps.api.exceptions import UnsupportedCredentialTypeError
+from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials.issuers import CourseCertificateIssuer, ProgramCertificateIssuer
 from credentials.apps.credentials.models import CourseCertificate, ProgramCertificate
 from credentials.apps.credentials.tests.factories import CourseCertificateFactory, ProgramCertificateFactory
@@ -15,7 +16,7 @@ from credentials.apps.credentials.tests.factories import CourseCertificateFactor
 LOGGER_NAME = 'credentials.apps.api.accreditors'
 
 
-class AccreditorTests(TestCase):
+class AccreditorTests(SiteMixin, TestCase):
     attributes = [{'name': 'whitelist_reason', 'value': 'Reason for whitelisting.'}]
     course_credential = CourseCertificate
     program_credential = ProgramCertificate
@@ -38,14 +39,14 @@ class AccreditorTests(TestCase):
         accreditor = Accreditor(issuers=[ProgramCertificateIssuer()])
         course_cert = CourseCertificateFactory()
         with self.assertRaises(UnsupportedCredentialTypeError):
-            accreditor.issue_credential(course_cert, 'tester', attributes=self.attributes)
+            accreditor.issue_credential(self.site, course_cert, 'tester', attributes=self.attributes)
 
     def test_issue_credential(self):
         """ Verify the method calls the Issuer's issue_credential method. """
         accreditor = Accreditor(issuers=[ProgramCertificateIssuer()])
         with patch.object(ProgramCertificateIssuer, 'issue_credential') as mock_method:
-            accreditor.issue_credential(self.program_cert, 'tester', attributes=self.attributes)
-            mock_method.assert_called_with(self.program_cert, 'tester', 'awarded', self.attributes)
+            accreditor.issue_credential(self.site, self.program_cert, 'tester', attributes=self.attributes)
+            mock_method.assert_called_with(self.site, self.program_cert, 'tester', 'awarded', self.attributes)
 
     def test_constructor_with_multiple_issuers_for_same_credential_type(self):
         """ Verify the Accreditor supports a single Issuer per credential type.

--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -166,7 +166,10 @@ class UserCredentialCreationSerializer(serializers.ModelSerializer):
         status = validated_data.get('status', UserCredentialStatus.AWARDED)
         attributes = validated_data.pop('attributes', None)
 
-        return accreditor.issue_credential(credential, username, status=status, attributes=attributes)
+        # Retrieve the current site from request
+        site = self.context['request'].site
+
+        return accreditor.issue_credential(site, credential, username, status=status, attributes=attributes)
 
     def create(self, validated_data):
         return self.issue_credential(validated_data)

--- a/credentials/apps/credentials/tests/test_issuer.py
+++ b/credentials/apps/credentials/tests/test_issuer.py
@@ -1,11 +1,12 @@
 """
 Tests for Issuer class.
 """
+import mock
 from django.test import TestCase
 
 from credentials.apps.api.exceptions import DuplicateAttributeError
 from credentials.apps.catalog.tests.factories import ProgramFactory
-from credentials.apps.core.tests.factories import SiteFactory, UserFactory
+from credentials.apps.core.tests.factories import SiteConfigurationFactory, SiteFactory, UserFactory
 from credentials.apps.credentials.issuers import CourseCertificateIssuer, ProgramCertificateIssuer
 from credentials.apps.credentials.models import CourseCertificate, ProgramCertificate, UserCredentialAttribute
 from credentials.apps.credentials.tests.factories import CourseCertificateFactory, ProgramCertificateFactory
@@ -22,10 +23,11 @@ class CertificateIssuerBase(object):
 
     def setUp(self):
         super(CertificateIssuerBase, self).setUp()
+        self.site = SiteFactory()
         self.certificate = self.cert_factory.create()
         self.username = 'tester'
         self.user = UserFactory(username=self.username)
-        self.user_cred = self.issuer.issue_credential(self.certificate, self.username)
+        self.user_cred = self.issuer.issue_credential(self.site, self.certificate, self.username)
         self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
 
     def test_issued_credential_type(self):
@@ -34,22 +36,21 @@ class CertificateIssuerBase(object):
 
     def test_issue_existing_credential(self):
         """ Verify credentials can be updated when re-issued."""
-
-        user_credential = self.issuer.issue_credential(self.certificate, self.username, 'revoked')
+        user_credential = self.issuer.issue_credential(self.site, self.certificate, self.username, 'revoked')
         self.user_cred.refresh_from_db()
         self._assert_usercredential_fields(self.user_cred, self.certificate, self.username, 'revoked', [])
         self.assertEqual(user_credential, self.user_cred)
 
     def test_issue_credential_without_attributes(self):
         """ Verify credentials can be issued without attributes."""
-
-        user_credential = self.issuer.issue_credential(self.certificate, self.username)
+        user_credential = self.issuer.issue_credential(self.site, self.certificate, self.username)
         self._assert_usercredential_fields(user_credential, self.certificate, self.username, 'awarded', [])
 
     def test_issue_credential_with_attributes(self):
         """ Verify credentials can be issued with attributes."""
         UserFactory(username='testuser2')
-        user_credential = self.issuer.issue_credential(self.certificate, 'testuser2', attributes=self.attributes)
+        user_credential = self.issuer.issue_credential(
+            self.site, self.certificate, 'testuser2', attributes=self.attributes)
         self._assert_usercredential_fields(user_credential, self.certificate, 'testuser2', 'awarded', self.attributes)
 
     def _assert_usercredential_fields(self, user_credential, expected_credential, expected_username, expected_status,
@@ -135,12 +136,35 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
 
     def setUp(self):
         self.site = SiteFactory()
+        self.site_config = SiteConfigurationFactory(site=self.site)
         self.program = ProgramFactory(site=self.site)
         self.certificate = self.cert_factory.create(program_uuid=self.program.uuid, site=self.site)
         self.username = 'tester'
         self.user = UserFactory(username=self.username)
-        self.user_cred = self.issuer.issue_credential(self.certificate, self.username)
+        self.user_cred = self.issuer.issue_credential(self.site, self.certificate, self.username)
         self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
+
+    def test_records_enabled_is_unchecked(self):
+        """Verify that if SiteConfiguration.records_enabled is unchecked then don't send
+        updated email to a pathway org.
+        """
+        self.site_config.records_enabled = False
+        self.site_config.save()
+
+        with mock.patch('credentials.apps.credentials.issuers.send_updated_emails_for_program') as mock_method:
+            self.issuer.issue_credential(self.site, self.certificate, 'testuser3', attributes=self.attributes)
+            self.assertEqual(mock_method.call_count, 0)
+
+        self.site_config.records_enabled = True
+        self.site_config.save()
+
+    def test_records_enabled_is_checked(self):
+        """Verify that if SiteConfiguration.records_enabled is checked and new record is created
+        then updated email is sent to a pathway org.
+        """
+        with mock.patch('credentials.apps.credentials.issuers.send_updated_emails_for_program') as mock_method:
+            self.issuer.issue_credential(self.site, self.certificate, 'testuser4', attributes=self.attributes)
+            self.assertEqual(mock_method.call_count, 1)
 
 
 class CourseCertificateIssuerTests(CertificateIssuerBase, TestCase):


### PR DESCRIPTION
#### Description 
If for some site the Site Configurations for credentials have the option "Enable Learner Records" unchecked, the programs are not being saved into the database when management command copy_catalog is called. Hence send_updated_emails_for_program() should be called only if the site
configurations has the value for records_enabled set to true.

#### Notes
* Added another check to verify that config has records_enabled set to true before sending an updated email to a pathway org

[PROD-189](https://openedx.atlassian.net/browse/PROD-189)


