### PR TITLE
Use site configuration from program credential instead of the actual request site.

### DIFF
--- a/credentials/apps/api/accreditors.py
+++ b/credentials/apps/api/accreditors.py
@@ -30,11 +30,10 @@ class Accreditor(object):
             else:
                 self.credential_type_issuer_map[credential_type] = issuer
 
-    def issue_credential(self, site, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
+    def issue_credential(self, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
         """Issues a credential.
 
         Arguments:
-            site (Site Object): The current site
             credential (AbstractCredential): Type of credential to issue.
             username (str): Username of the recipient.
             status (str): Status of credential.
@@ -55,4 +54,4 @@ class Accreditor(object):
                 )
             )
 
-        return credential_issuer.issue_credential(site, credential, username, status, attributes)
+        return credential_issuer.issue_credential(credential, username, status, attributes)

--- a/credentials/apps/api/tests/test_accreditors.py
+++ b/credentials/apps/api/tests/test_accreditors.py
@@ -8,7 +8,6 @@ from testfixtures import LogCapture
 
 from credentials.apps.api.accreditors import Accreditor
 from credentials.apps.api.exceptions import UnsupportedCredentialTypeError
-from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials.issuers import CourseCertificateIssuer, ProgramCertificateIssuer
 from credentials.apps.credentials.models import CourseCertificate, ProgramCertificate
 from credentials.apps.credentials.tests.factories import CourseCertificateFactory, ProgramCertificateFactory
@@ -16,7 +15,7 @@ from credentials.apps.credentials.tests.factories import CourseCertificateFactor
 LOGGER_NAME = 'credentials.apps.api.accreditors'
 
 
-class AccreditorTests(SiteMixin, TestCase):
+class AccreditorTests(TestCase):
     attributes = [{'name': 'whitelist_reason', 'value': 'Reason for whitelisting.'}]
     course_credential = CourseCertificate
     program_credential = ProgramCertificate
@@ -39,14 +38,14 @@ class AccreditorTests(SiteMixin, TestCase):
         accreditor = Accreditor(issuers=[ProgramCertificateIssuer()])
         course_cert = CourseCertificateFactory()
         with self.assertRaises(UnsupportedCredentialTypeError):
-            accreditor.issue_credential(self.site, course_cert, 'tester', attributes=self.attributes)
+            accreditor.issue_credential(course_cert, 'tester', attributes=self.attributes)
 
     def test_issue_credential(self):
         """ Verify the method calls the Issuer's issue_credential method. """
         accreditor = Accreditor(issuers=[ProgramCertificateIssuer()])
         with patch.object(ProgramCertificateIssuer, 'issue_credential') as mock_method:
-            accreditor.issue_credential(self.site, self.program_cert, 'tester', attributes=self.attributes)
-            mock_method.assert_called_with(self.site, self.program_cert, 'tester', 'awarded', self.attributes)
+            accreditor.issue_credential(self.program_cert, 'tester', attributes=self.attributes)
+            mock_method.assert_called_with(self.program_cert, 'tester', 'awarded', self.attributes)
 
     def test_constructor_with_multiple_issuers_for_same_credential_type(self):
         """ Verify the Accreditor supports a single Issuer per credential type.

--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -166,10 +166,7 @@ class UserCredentialCreationSerializer(serializers.ModelSerializer):
         status = validated_data.get('status', UserCredentialStatus.AWARDED)
         attributes = validated_data.pop('attributes', None)
 
-        # Retrieve the current site from request
-        site = self.context['request'].site
-
-        return accreditor.issue_credential(site, credential, username, status=status, attributes=attributes)
+        return accreditor.issue_credential(credential, username, status=status, attributes=attributes)
 
     def create(self, validated_data):
         return self.issue_credential(validated_data)

--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -125,7 +125,10 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
         # Send an updated email to a pathway org only if the user has previously sent one
         # This function call should be moved into some type of task queue
         # once credentials has that functionality
-        if created:
+        site_config = getattr(credential.site, 'siteconfiguration', None)
+        # Add a check to see if records_enabled is True for the site associated with
+        # the credentials. If records is not enabled, we should not send this email
+        if created and site_config and site_config.records_enabled:
             send_updated_emails_for_program(username, credential)
 
         self.set_credential_attributes(user_credential, attributes)

--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -36,7 +36,7 @@ class AbstractCredentialIssuer(object):
         raise NotImplementedError  # pragma: no cover
 
     @transaction.atomic
-    def issue_credential(self, site, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):  # pylint: disable=unused-argument
+    def issue_credential(self, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
         """
         Issue a credential to the user.
 
@@ -44,7 +44,6 @@ class AbstractCredentialIssuer(object):
         existing credential WILL be modified.
 
         Arguments:
-            site (Site Object): The current site
             credential (AbstractCredential): Type of credential to issue.
             username (str): username of user for which credential required
             status (str): status of credential
@@ -94,7 +93,7 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
     issued_credential_type = ProgramCertificate
 
     @transaction.atomic
-    def issue_credential(self, site, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
+    def issue_credential(self, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
         """
         Issue a Program Certificate to the user.
 
@@ -106,7 +105,6 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
         WILL be modified.
 
         Arguments:
-            site (Site Object): The current site
             credential (AbstractCredential): Type of credential to issue.
             username (str): username of user for which credential required
             status (str): status of credential
@@ -127,9 +125,7 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
         # Send an updated email to a pathway org only if the user has previously sent one
         # This function call should be moved into some type of task queue
         # once credentials has that functionality
-        # Add a check to see if records_enabled is True for the site, if not then we should
-        # not invoke send_updated_emails_for_program()
-        if created and hasattr(site, 'siteconfiguration') and site.siteconfiguration.records_enabled:
+        if created:
             send_updated_emails_for_program(username, credential)
 
         self.set_credential_attributes(user_credential, attributes)

--- a/credentials/apps/credentials/tests/test_issuer.py
+++ b/credentials/apps/credentials/tests/test_issuer.py
@@ -1,12 +1,11 @@
 """
 Tests for Issuer class.
 """
-import mock
 from django.test import TestCase
 
 from credentials.apps.api.exceptions import DuplicateAttributeError
 from credentials.apps.catalog.tests.factories import ProgramFactory
-from credentials.apps.core.tests.factories import SiteConfigurationFactory, SiteFactory, UserFactory
+from credentials.apps.core.tests.factories import SiteFactory, UserFactory
 from credentials.apps.credentials.issuers import CourseCertificateIssuer, ProgramCertificateIssuer
 from credentials.apps.credentials.models import CourseCertificate, ProgramCertificate, UserCredentialAttribute
 from credentials.apps.credentials.tests.factories import CourseCertificateFactory, ProgramCertificateFactory
@@ -23,11 +22,10 @@ class CertificateIssuerBase(object):
 
     def setUp(self):
         super(CertificateIssuerBase, self).setUp()
-        self.site = SiteFactory()
         self.certificate = self.cert_factory.create()
         self.username = 'tester'
         self.user = UserFactory(username=self.username)
-        self.user_cred = self.issuer.issue_credential(self.site, self.certificate, self.username)
+        self.user_cred = self.issuer.issue_credential(self.certificate, self.username)
         self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
 
     def test_issued_credential_type(self):
@@ -36,21 +34,22 @@ class CertificateIssuerBase(object):
 
     def test_issue_existing_credential(self):
         """ Verify credentials can be updated when re-issued."""
-        user_credential = self.issuer.issue_credential(self.site, self.certificate, self.username, 'revoked')
+
+        user_credential = self.issuer.issue_credential(self.certificate, self.username, 'revoked')
         self.user_cred.refresh_from_db()
         self._assert_usercredential_fields(self.user_cred, self.certificate, self.username, 'revoked', [])
         self.assertEqual(user_credential, self.user_cred)
 
     def test_issue_credential_without_attributes(self):
         """ Verify credentials can be issued without attributes."""
-        user_credential = self.issuer.issue_credential(self.site, self.certificate, self.username)
+
+        user_credential = self.issuer.issue_credential(self.certificate, self.username)
         self._assert_usercredential_fields(user_credential, self.certificate, self.username, 'awarded', [])
 
     def test_issue_credential_with_attributes(self):
         """ Verify credentials can be issued with attributes."""
         UserFactory(username='testuser2')
-        user_credential = self.issuer.issue_credential(
-            self.site, self.certificate, 'testuser2', attributes=self.attributes)
+        user_credential = self.issuer.issue_credential(self.certificate, 'testuser2', attributes=self.attributes)
         self._assert_usercredential_fields(user_credential, self.certificate, 'testuser2', 'awarded', self.attributes)
 
     def _assert_usercredential_fields(self, user_credential, expected_credential, expected_username, expected_status,
@@ -136,35 +135,12 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
 
     def setUp(self):
         self.site = SiteFactory()
-        self.site_config = SiteConfigurationFactory(site=self.site)
         self.program = ProgramFactory(site=self.site)
         self.certificate = self.cert_factory.create(program_uuid=self.program.uuid, site=self.site)
         self.username = 'tester'
         self.user = UserFactory(username=self.username)
-        self.user_cred = self.issuer.issue_credential(self.site, self.certificate, self.username)
+        self.user_cred = self.issuer.issue_credential(self.certificate, self.username)
         self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
-
-    def test_records_enabled_is_unchecked(self):
-        """Verify that if SiteConfiguration.records_enabled is unchecked then don't send
-        updated email to a pathway org.
-        """
-        self.site_config.records_enabled = False
-        self.site_config.save()
-
-        with mock.patch('credentials.apps.credentials.issuers.send_updated_emails_for_program') as mock_method:
-            self.issuer.issue_credential(self.site, self.certificate, 'testuser3', attributes=self.attributes)
-            self.assertEqual(mock_method.call_count, 0)
-
-        self.site_config.records_enabled = True
-        self.site_config.save()
-
-    def test_records_enabled_is_checked(self):
-        """Verify that if SiteConfiguration.records_enabled is checked and new record is created
-        then updated email is sent to a pathway org.
-        """
-        with mock.patch('credentials.apps.credentials.issuers.send_updated_emails_for_program') as mock_method:
-            self.issuer.issue_credential(self.site, self.certificate, 'testuser4', attributes=self.attributes)
-            self.assertEqual(mock_method.call_count, 1)
 
 
 class CourseCertificateIssuerTests(CertificateIssuerBase, TestCase):


### PR DESCRIPTION
Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [x] Request a review if desired
  - [x] Squash/Fixup your branch to one commit

This is a revert of https://github.com/edx/credentials/pull/643 because that didn't fix the prod issue we are seeing. This change uses the same mechanism to fix prod issue, but we are using the site config from the program cert instead of the request.