### PR TITLE
Pin django to 1.11.22

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 analytics-python==1.2.9
 coreapi==2.3.1
-django<2.0
+django==1.11.22
 django-hijack==2.1.7
 django-extensions==1.7.9
 django-filter==1.0.4


### PR DESCRIPTION
It looks like when new AMIs are built for this, they aren't necessarily build from scratch, and since any Django version under 2.0 will satisfy the pip requirement of "django<2.0", Django won't just get upgraded on build.  So I'm pinning an explicit version again.

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
