### PR TITLE
Fix program record url in credit request email.

### DIFF
--- a/credentials/apps/api/accreditors.py
+++ b/credentials/apps/api/accreditors.py
@@ -30,7 +30,12 @@ class Accreditor(object):
             else:
                 self.credential_type_issuer_map[credential_type] = issuer
 
-    def issue_credential(self, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
+    def issue_credential(
+            self, credential, username,
+            status=UserCredentialStatus.AWARDED,
+            attributes=None,
+            request=None
+    ):
         """Issues a credential.
 
         Arguments:
@@ -38,6 +43,7 @@ class Accreditor(object):
             username (str): Username of the recipient.
             status (str): Status of credential.
             attributes (List[dict]): attributes list containing dictionaries of attributes
+            request (HttpRequest): request object to build program record absolute uris
 
         Returns:
             UserCredential
@@ -54,4 +60,4 @@ class Accreditor(object):
                 )
             )
 
-        return credential_issuer.issue_credential(credential, username, status, attributes)
+        return credential_issuer.issue_credential(credential, username, status, attributes, request)

--- a/credentials/apps/api/tests/test_accreditors.py
+++ b/credentials/apps/api/tests/test_accreditors.py
@@ -45,7 +45,7 @@ class AccreditorTests(TestCase):
         accreditor = Accreditor(issuers=[ProgramCertificateIssuer()])
         with patch.object(ProgramCertificateIssuer, 'issue_credential') as mock_method:
             accreditor.issue_credential(self.program_cert, 'tester', attributes=self.attributes)
-            mock_method.assert_called_with(self.program_cert, 'tester', 'awarded', self.attributes)
+            mock_method.assert_called_with(self.program_cert, 'tester', 'awarded', self.attributes, None)
 
     def test_constructor_with_multiple_issuers_for_same_credential_type(self):
         """ Verify the Accreditor supports a single Issuer per credential type.

--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -165,8 +165,9 @@ class UserCredentialCreationSerializer(serializers.ModelSerializer):
         username = validated_data['username']
         status = validated_data.get('status', UserCredentialStatus.AWARDED)
         attributes = validated_data.pop('attributes', None)
+        request = self.context.get('request')
 
-        return accreditor.issue_credential(credential, username, status=status, attributes=attributes)
+        return accreditor.issue_credential(credential, username, status=status, attributes=attributes, request=request)
 
     def create(self, validated_data):
         return self.issue_credential(validated_data)

--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -36,7 +36,12 @@ class AbstractCredentialIssuer(object):
         raise NotImplementedError  # pragma: no cover
 
     @transaction.atomic
-    def issue_credential(self, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
+    def issue_credential(
+            self, credential, username,
+            status=UserCredentialStatus.AWARDED,
+            attributes=None,
+            request=None    # pylint: disable=unused-argument
+    ):
         """
         Issue a credential to the user.
 
@@ -48,6 +53,7 @@ class AbstractCredentialIssuer(object):
             username (str): username of user for which credential required
             status (str): status of credential
             attributes (List[dict]): optional list of attributes that should be associated with the issued credential.
+            request (HttpRequest): request object to build program record absolute uris
 
         Returns:
             UserCredential
@@ -93,7 +99,12 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
     issued_credential_type = ProgramCertificate
 
     @transaction.atomic
-    def issue_credential(self, credential, username, status=UserCredentialStatus.AWARDED, attributes=None):
+    def issue_credential(
+            self, credential, username,
+            status=UserCredentialStatus.AWARDED,
+            attributes=None,
+            request=None
+    ):
         """
         Issue a Program Certificate to the user.
 
@@ -109,6 +120,7 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
             username (str): username of user for which credential required
             status (str): status of credential
             attributes (List[dict]): optional list of attributes that should be associated with the issued credential.
+            request (HttpRequest): request object to build program record absolute uris
 
         Returns:
             UserCredential
@@ -129,7 +141,7 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
         # Add a check to see if records_enabled is True for the site associated with
         # the credentials. If records is not enabled, we should not send this email
         if created and site_config and site_config.records_enabled:
-            send_updated_emails_for_program(username, credential)
+            send_updated_emails_for_program(request, username, credential)
 
         self.set_credential_attributes(user_credential, attributes)
 

--- a/credentials/apps/records/utils.py
+++ b/credentials/apps/records/utils.py
@@ -14,7 +14,7 @@ from credentials.apps.records.models import ProgramCertRecord, UserCreditPathway
 logger = logging.getLogger(__name__)
 
 
-def send_updated_emails_for_program(username, program_certificate):
+def send_updated_emails_for_program(request, username, program_certificate):
         """ If the user has previously sent an email to a pathway org, we want to send
         an updated one when they finish the program.  This function is called from the
         credentials Program Certificate awarding API """
@@ -42,7 +42,7 @@ def send_updated_emails_for_program(username, program_certificate):
 
             pathway = user_pathway.pathway
             record_path = reverse('records:public_programs', kwargs={'uuid': pcr.uuid.hex})
-            record_link = site.domain + record_path
+            record_link = request.build_absolute_uri(record_path)
             csv_link = urllib.parse.urljoin(record_link, "csv")
 
             msg = ProgramCreditRequest(site).personalize(


### PR DESCRIPTION
Building the program record URL incorrectly by concatenating site domain and record path. Fixed by using request.build_absolute_uri().

PROD-564

Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
