### PR TITLE
Retired program credential is showing on dashboard

### DIFF
--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -140,7 +140,6 @@ class RecordsViewTests(SiteMixin, TestCase):
 
     @ddt.data(
         (Program.ACTIVE, True),
-        (Program.RETIRED, True),
         (Program.DELETED, False),
         (Program.UNPUBLISHED, False),
     )

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -280,7 +280,7 @@ class RecordsListBaseView(LoginRequiredMixin, RecordsEnabledMixin, TemplateView,
 
 class RecordsView(RecordsListBaseView):
     def _get_programs(self):
-        return self._programs_context(include_empty_programs=False, include_retired_programs=True)
+        return self._programs_context(include_empty_programs=False)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## [PROD-596](https://openedx.atlassian.net/browse/PROD-596)

### Description
Currently, if a learner is enrolled in a course-run which is a part of a retired program then that retired program start appearing on program dashboard.Once the program is retired,it must not be shown on the program dashboard in any case.