### PR TITLE
ProgramCertRecord search view update in Admin Panel

### DIFF
--- a/credentials/apps/records/admin.py
+++ b/credentials/apps/records/admin.py
@@ -9,7 +9,7 @@ from credentials.apps.records.models import ProgramCertRecord, UserCreditPathway
 class ProgramCertRecordAdmin(admin.ModelAdmin):
     """ Admin for the ProgramCertRecord model."""
     list_display = ('uuid', 'program', 'user',)
-    search_fields = ('uuid', 'program', 'user',)
+    search_fields = ('uuid', 'program__title', 'user__username',)
     raw_id_fields = ('program', 'user',)
     exclude = ('certificate',)
 


### PR DESCRIPTION
**Ticket:** [Learner-6666](https://openedx.atlassian.net/browse/LEARNER-6666)

**Details:** 
Search field in admin view for program certificates returns 500 server error for all the inputs. 
https://credentials.edx.org/admin/records/programcertrecord/

**Solution:**
In the code, foriegn keys were being used instead of column names. 
Updated the correct column names for the search view. 