### PR TITLE
Changed from_address while sending email to partner

### DIFF
--- a/credentials/apps/records/messages.py
+++ b/credentials/apps/records/messages.py
@@ -2,13 +2,13 @@ from edx_ace import MessageType
 
 
 class ProgramCreditRequest(MessageType):
-    def __init__(self, site, *args, **kwargs):
+    def __init__(self, site, user_email, *args, **kwargs):
         super(ProgramCreditRequest, self).__init__(*args, **kwargs)
 
-        if site.siteconfiguration.partner_from_address:
-            from_address = site.siteconfiguration.partner_from_address
-        else:
-            from_address = 'no-reply@' + site.domain
+        if not user_email:
+            raise Exception("User email is missing.")
+
+        from_address = user_email
 
         self.options.update({  # pylint: disable=no-member
             'from_address': from_address,

--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -28,6 +28,7 @@ from credentials.apps.credentials.models import UserCredential
 from credentials.apps.credentials.tests.factories import (CourseCertificateFactory, ProgramCertificateFactory,
                                                           UserCredentialAttributeFactory, UserCredentialFactory)
 from credentials.apps.records.constants import UserCreditPathwayStatus
+from credentials.apps.records.messages import ProgramCreditRequest
 from credentials.apps.records.models import ProgramCertRecord, UserCreditPathway
 from credentials.apps.records.tests.factories import (ProgramCertRecordFactory, UserCreditPathwayFactory,
                                                       UserGradeFactory)
@@ -825,11 +826,11 @@ class ProgramSendTests(SiteMixin, TestCase):
 
     @patch('credentials.apps.records.views.ace')
     def test_from_address_set(self, mock_ace):
-        """ Verify that the email uses the proper from address """
+        """ Verify that the email uses the proper from address  and learner address"""
         response = self.post()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(mock_ace.send.call_args[0][0].options['from_address'],
-                         self.site_configuration.partner_from_address)
+                         self.user.email)
 
     @patch('credentials.apps.records.views.ace')
     def test_no_full_name(self, mock_ace):
@@ -844,16 +845,15 @@ class ProgramSendTests(SiteMixin, TestCase):
         self.assertEqual(mock_ace.send.call_args[0][0].context['user_full_name'],
                          self.user.username)
 
-    @patch('credentials.apps.records.views.ace')
-    def test_from_address_unset(self, mock_ace):
-        """ Verify that the email uses the proper default from address """
-        self.site_configuration.partner_from_address = None
+    def test_from_address_unset(self):
+        """ Verify that the exception is raised if email was none """
+        self.user.email = None
         self.site_configuration.save()
 
         response = self.post()
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(mock_ace.send.call_args[0][0].options['from_address'],
-                         'no-reply@' + self.site.domain)  # pylint: disable=no-member
+        with self.assertRaisesMessage(Exception, "User email is missing."):
+            ProgramCreditRequest(self.site, self.user.email)
 
     def test_email_content_complete(self):
         """Verify an email is actually sent"""
@@ -874,7 +874,7 @@ class ProgramSendTests(SiteMixin, TestCase):
         self.assertIn("has sent their completed program record for", message)
         self.assertIn("<a href=\"" + record_link + "\">View Program Record</a>", message)
         self.assertIn("<a href=\"" + csv_link + "\">Download Record (CSV)</a>", message)
-        self.assertEqual(self.site_configuration.partner_from_address, email.from_email)
+        self.assertEqual(self.user.email, email.from_email)
         self.assertListEqual([self.pathway.email], email.to)
 
     def test_email_content_incomplete(self):

--- a/credentials/apps/records/utils.py
+++ b/credentials/apps/records/utils.py
@@ -45,7 +45,7 @@ def send_updated_emails_for_program(request, username, program_certificate):
             record_link = request.build_absolute_uri(record_path)
             csv_link = urllib.parse.urljoin(record_link, "csv")
 
-            msg = ProgramCreditRequest(site).personalize(
+            msg = ProgramCreditRequest(site, user.email).personalize(
                 recipient=Recipient(username=None, email_address=pathway.email),
                 language=program_certificate.language,
                 user_context={

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -417,8 +417,7 @@ class ProgramSendView(LoginRequiredMixin, RatelimitMixin, RecordsEnabledMixin, V
         record_path = reverse('records:public_programs', kwargs={'uuid': public_record.uuid.hex})
         record_link = request.build_absolute_uri(record_path)
         csv_link = urllib.parse.urljoin(record_link, "csv")
-
-        msg = ProgramCreditRequest(request.site).personalize(
+        msg = ProgramCreditRequest(request.site, user.email).personalize(
             recipient=Recipient(username=None, email_address=pathway.email),
             language=certificate.language,
             user_context={


### PR DESCRIPTION
previously we were using learner-records@edx.org in from address.
Now we will be using learner email address so that partner can
contact with learner.

Prod-624