### PR TITLE
Invalid UUID error in credentials api view

### DIFF
--- a/credentials/apps/api/v2/filters.py
+++ b/credentials/apps/api/v2/filters.py
@@ -1,4 +1,5 @@
 import django_filters
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 
 from credentials.apps.catalog.models import Program
@@ -8,8 +9,14 @@ from credentials.apps.credentials.utils import filter_visible
 
 class ProgramRelatedFilter(django_filters.Filter):
     def filter(self, qs, value):
-        program = Program.objects.filter(uuid=value).first()
-        course_runs = [run.key for run in program.course_runs.all()] if program else []
+        try:
+            program = Program.objects.filter(uuid=value).first()
+        except ValidationError:
+            return UserCredential.objects.none()
+
+        course_runs = [
+            run.key for run in program.course_runs.all()
+        ] if program else []
         return qs.filter(Q(program_credentials__program_uuid=value) |
                          Q(course_credentials__course_id__in=course_runs))
 
@@ -38,7 +45,9 @@ class UserCredentialFilter(django_filters.FilterSet):
         choices=UserCredential._meta.get_field('status').choices,
         label='Status of the credential'
     )
-    username = django_filters.CharFilter(label='Username of the recipient of the credential')
+    username = django_filters.CharFilter(
+        label='Username of the recipient of the credential'
+    )
     only_visible = django_filters.BooleanFilter(method=handle_only_visible)
 
     class Meta:

--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -256,6 +256,15 @@ class CredentialViewSetTests(SiteMixin, APITestCase):
 
         self.assert_list_username_filter_request_succeeds(username, expected)
 
+    def test_innvalid_program_uuid_filtering(self):
+        """ Verify that endpoint returns no results for invalid program uuid
+        instead of raising ValidationError. """
+        self.authenticate_user(self.user)
+        self.add_user_permission(self.user, 'view_usercredential')
+
+        response = self.client.get(self.list_path + '?program_uuid=1234fewef')
+        self.assertListEqual(response.data['results'], [])
+
     def test_list_program_uuid_filtering(self):
         """ Verify the endpoint returns data for all UserCredentials in the given program. """
 


### PR DESCRIPTION
[Learner-5999](https://openedx.atlassian.net/browse/LEARNER-5999)

**Problem**
Giving invalid uuid in credentials api raises a validation exception.

**Solution**
Added an except clause to return an empty list in case of invalid UUID instead of raising an exception.
Test checks if invalid UUID returns an empty list instead of raising validation error or not.