### PR TITLE
Restriction on the version of MySql that we use for testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   db:
-    image: mysql:5.6
+    image: mysql:5.6.45
     container_name: db
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
     environment:


### PR DESCRIPTION
[PROD-830]

This is being added to deal with a failure in tests running with the
current version.

Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [x] Request a review if desired
  - [x] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
