### PR TITLE
ARCH-1269: upgrade edx-drf-extensions to 2.4.5

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -374,7 +374,6 @@ JWT_AUTH = {
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
 }
 
 # Email sending

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -51,7 +51,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.1
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-i18n-tools==0.4.8
 edx-lint==0.5.5
 edx-opaque-keys==2.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.1
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-opaque-keys==2.0.0
 edx-rest-api-client==1.9.2
 git+https://github.com/edx/credentials-themes.git@0.1.27#egg=edx_credentials_themes==0.1.27

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -49,7 +49,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.1
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-i18n-tools==0.4.8
 edx-lint==0.5.5
 edx-opaque-keys==2.0.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -35,7 +35,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.1
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-opaque-keys==2.0.0
 edx-rest-api-client==1.9.2
 git+https://github.com/edx/credentials-themes.git@0.1.27#egg=edx_credentials_themes==0.1.27

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -40,7 +40,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.1
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.5
 edx-lint==0.5.5
 edx-opaque-keys==2.0.0
 edx-rest-api-client==1.9.2


### PR DESCRIPTION
- Upgrade edx-drf-extensions to 2.4.5
- Remove unused JWT_AUTH_REFRESH_COOKIE setting.

ARCH-418, ARCH-1269, ARCH-1044

Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
