### PR TITLE
Squash any last remaining attempts to read the old columns.

### DIFF
--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -97,6 +97,15 @@ class CourseRunField(serializers.Field):
 
     def to_internal_value(self, data):
         site = self.context['request'].site
+
+        # The following two conditions add transitionary logic while migrating off the old field names.
+        if 'start' in data:
+            data['start_date'] = data['start']
+            del data['start']
+        if 'end' in data:
+            data['end_date'] = data['end']
+            del data['end']
+
         try:
             return CourseRun.objects.get(key=data, course__site=site)
         except ObjectDoesNotExist:


### PR DESCRIPTION
This is to fix errors that appeared in newrelic:

1. [/credentials.apps.api.v2.views:GradeViewSet.create](https://rpm.newrelic.com/accounts/88178/applications/15136782/filterable_errors#/show/49a73f9f-026c-11ea-be06-0242ac110007_20842_29248/stack_trace?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart): (1054, "Unknown column 'catalog_courserun.start' in 'field list'")
2. [/credentials.apps.api.v2.views:CredentialViewSet.list](https://rpm.newrelic.com/accounts/88178/applications/15136782/filterable_errors#/show/49a73f9f-026c-11ea-be06-0242ac110007_6490_14191/stack_trace?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart): (1054, "Unknown column 'catalog_courserun.start' in 'field list'")
3. [/credentials.apps.records.views:ProgramRecordView.get](https://rpm.newrelic.com/accounts/88178/applications/15136782/filterable_errors#/show/2366bb96-026c-11ea-be06-0242ac110007_0_7675/stack_trace?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart): (1054, "Unknown column 'catalog_courserun.start' in 'field list'")