### PR TITLE
Rename start and end fields (4.1/4)

### DIFF
--- a/credentials/apps/catalog/models.py
+++ b/credentials/apps/catalog/models.py
@@ -56,10 +56,6 @@ class CourseRun(TimeStampedModel):
     start_date = models.DateTimeField(null=True, blank=True, db_index=True)
     end_date = models.DateTimeField(null=True, blank=True, db_index=True)
 
-    # TODO: delete these two fields during the last stage of rolling out the field renames.
-    start = models.DateTimeField(null=True, blank=True, db_index=True)
-    end = models.DateTimeField(null=True, blank=True, db_index=True)
-
     # Note that we don't have a status field here -- there are only two statuses for CourseRuns: published and
     # unpublished. But unpublished is really used as a 'retired' flag. So in both cases, we want the run.
 


### PR DESCRIPTION
This is the 4.1th stage of renaming the start and end fields of
CourseRun to start_date and end_date.

This release ONLY removes the django model fields corresponding to the
old columns.  Note that this does not include the migration to remove
the columns.

DE-1708

Testing in devstack
---
To test, I added a "dummy" column into the middle of the core_user table:

```
mysql> ALTER TABLE core_user ADD COLUMN dummy varchar(255) NULL AFTER username;
Query OK, 0 rows affected (0.09 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> describe core_user;
+--------------+--------------+------+-----+---------+----------------+
| Field        | Type         | Null | Key | Default | Extra          |
+--------------+--------------+------+-----+---------+----------------+
| id           | int(11)      | NO   | PRI | NULL    | auto_increment |
| password     | varchar(128) | NO   |     | NULL    |                |
| last_login   | datetime(6)  | YES  |     | NULL    |                |
| is_superuser | tinyint(1)   | NO   |     | NULL    |                |
| username     | varchar(150) | NO   | UNI | NULL    |                |
| dummy        | varchar(255) | YES  |     | NULL    |                |
| first_name   | varchar(30)  | NO   |     | NULL    |                |
| last_name    | varchar(30)  | NO   |     | NULL    |                |
| email        | varchar(254) | NO   |     | NULL    |                |
| is_staff     | tinyint(1)   | NO   |     | NULL    |                |
| is_active    | tinyint(1)   | NO   |     | NULL    |                |
| date_joined  | datetime(6)  | NO   |     | NULL    |                |
| full_name    | varchar(255) | YES  |     | NULL    |                |
+--------------+--------------+------+-----+---------+----------------+
13 rows in set (0.00 sec)
```

From the django python shell, no exceptions and no issue with column ordering:

```
>>> from credentials.apps.core.models import User
>>> edx_user = User.objects.get(username='edx')
>>> edx_user.date_joined
datetime.datetime(2019, 5, 3, 14, 26, 22, 946942, tzinfo=<UTC>)
```

Even if I attempt to fetch all values from all objects, no mention of dummy nor any exception thrown:
```
>>> User.objects.all().values()
<QuerySet [{'username': 'credentials_service_user', 'full_name': None, 'id': 1, 'is_superuser': False, 'password': '!RB3TirqFTPlqSlc7Vuz50T9lEIHCs06o6m6GGNS5', 'first_name': '', 'date_joined': datetime.datetime(2019, 5, 3, 14, 26, 16, 618946, tzinfo=<UTC>), 'is_staff': True, 'last_name': '', 'last_login': None, 'email': '', 'is_active': True}, {'username': 'edx', 'full_name': '', 'id': 2, 'is_superuser': True, 'password': 'pbkdf2_sha256$36000$tVpJdzOLAUhI$JdXJrZFSxUEueoMvjsJw0MWzeGq3SaU3Ucy7cMMQQa4=', 'first_name': '', 'date_joined': datetime.datetime(2019, 5, 3, 14, 26, 22, 946942, tzinfo=<UTC>), 'is_staff': True, 'last_name': '', 'last_login': datetime.datetime(2019, 8, 12, 17, 2, 34, 521298, tzinfo=<UTC>), 'email': 'edx@example.com', 'is_active': True}]>
```