### PR TITLE
Grades on learner record are not consistent with progress page.

### DIFF
--- a/credentials/static/components/ProgramRecord.jsx
+++ b/credentials/static/components/ProgramRecord.jsx
@@ -128,7 +128,7 @@ class ProgramRecord extends React.Component {
       return decimal;
     }
 
-    return parseInt(decimal * 100, 10).toString() + '%';
+    return parseInt(Math.round(decimal * 100), 10).toString() + '%';
   }
 
   formatGradeData() {


### PR DESCRIPTION
## [PROD-1051](https://openedx.atlassian.net/browse/PROD-1051)
### Description
Credentials service is not rounding the user grade in a particular course while displaying it on the learner record.This makes an inconsistent behaviour compared to support tool as well as progress
page.To fix it, learner grade are rounded properly so that a consistent grade would appear on all views.