### PR TITLE
Address an issue that was preventing make upgrade

### DIFF
--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==4.3.0
+pip-tools==4.4.0
 six==1.14.0               # via pip-tools


### PR DESCRIPTION
It seems like there was a pip/piptools version incompatibility which
was preventing make upgrade from even getting started

Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [x] Squash/Fixup your branch to one commit
