### PR TITLE
Upgrade django-ratelimit BOM-1259

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -71,7 +71,7 @@ PROJECT_APPS = [
 INSTALLED_APPS += THIRD_PARTY_APPS
 INSTALLED_APPS += PROJECT_APPS
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -421,7 +421,7 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
         'debug_toolbar',
     ]
 
-    MIDDLEWARE_CLASSES += (
+    MIDDLEWARE += (
         'debug_toolbar.middleware.DebugToolbarMiddleware',
     )
 

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 analytics-python==1.2.9
 argparse==1.4.0
 astroid==1.5.2
@@ -13,7 +14,7 @@ bok-choy==1.0.1
 boto==2.49.0
 cached-property==1.5.1
 certifi==2019.11.28
-cffi==1.13.2
+cffi==1.14.0
 chardet==3.0.4
 click-log==0.1.8
 click==7.0
@@ -26,10 +27,9 @@ defusedxml==0.6.0
 django-appconf==1.0.3
 django-compat==1.0.15
 django-debug-toolbar==1.6
-django-extensions==2.2.6
+django-extensions==2.2.8
 django-filter==1.0.4
 django-hijack==2.1.10
-django-ratelimit==2.0.0
 django-rest-swagger==2.2.0
 django-ses==0.8.14
 django-sortedm2m==3.0.0
@@ -37,19 +37,19 @@ django-statici18n==1.9.0
 django-storages==1.8
 django-waffle==0.19.0
 django-webpack-loader==0.6.0
-django==1.11.27
+django==1.11.28
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
-docker-compose==1.25.3
-docker[ssh]==4.1.0
+docker-compose==1.25.4
+docker[ssh]==4.2.0
 dockerpty==0.4.1
 docopt==0.6.2
 edx-ace==0.1.12
-edx-auth-backends==2.0.2
+edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
-edx-django-utils==2.0.3
-edx-drf-extensions==2.4.5
+edx-django-utils==2.0.4
+edx-drf-extensions==2.4.6
 edx-i18n-tools==0.5.0
 edx-lint==0.5.5
 edx-opaque-keys==2.0.1
@@ -66,18 +66,18 @@ idna==2.7
 importlib-metadata==1.5.0
 isort==4.2.5
 itypes==1.1.0
-jinja2==2.11.0
+jinja2==2.11.1
 jsonschema==3.2.0
 lazy-object-proxy==1.4.3
 lazy==1.4
-markdown==3.1.1
+markdown==3.2
 markupsafe==1.1.1
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==8.2.0
 mysqlclient==1.4.6
-newrelic==5.4.1.134
-nodeenv==1.3.4
+newrelic==5.6.0.135
+nodeenv==1.3.5
 oauthlib==3.1.0
 olefile==0.46
 openapi-codec==1.3.2
@@ -93,7 +93,7 @@ polib==1.1.0
 psutil==1.2.1
 py==1.8.1
 pycparser==2.19
-pycryptodomex==3.9.4
+pycryptodomex==3.9.6
 pygments==2.5.2
 pyinotify==0.9.6 ; "linux" in sys_platform
 pyjwkest==1.3.2
@@ -124,11 +124,11 @@ semantic-version==2.8.4
 simplejson==3.17.0
 six==1.14.0
 slumber==0.7.1
-social-auth-app-django==1.2.0
-social-auth-core[openidconnect]==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sqlparse==0.3.0
 stevedore==1.10.0
-testfixtures==6.11.0
+testfixtures==6.12.0
 text-unidecode==1.3
 texttable==1.6.2
 transifex-client==0.13.7

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,7 +16,6 @@ django-debug-toolbar
 django-hijack
 django-extensions
 django-filter
-django-ratelimit
 django-rest-swagger
 django-sortedm2m
 django-statici18n
@@ -46,3 +45,6 @@ xss-utils
 
 # TODO Install in configuration
 git+https://github.com/edx/credentials-themes.git@0.1.30#egg=edx_credentials_themes==0.1.30
+
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
+

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,9 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 analytics-python==1.2.9
+argparse==1.4.0           # via stevedore
 attrs==17.4.0             # via edx-ace
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
@@ -14,44 +16,44 @@ defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-appconf==1.0.3     # via django-statici18n
 django-compat==1.0.15     # via django-hijack
 django-debug-toolbar==1.6
-django-extensions==2.2.6
+django-extensions==2.2.8
 django-filter==1.0.4
 django-hijack==2.1.10
-django-ratelimit==2.0.0
 django-rest-swagger==2.2.0
 django-sortedm2m==3.0.0
 django-statici18n==1.9.0
 django-storages==1.8
 django-waffle==0.19.0
 django-webpack-loader==0.6.0
-django==1.11.27
+django==1.11.28
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
 edx-ace==0.1.12
-edx-auth-backends==2.0.2
+edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
-edx-django-utils==2.0.3
-edx-drf-extensions==2.4.5
+edx-django-utils==2.0.4
+edx-drf-extensions==2.4.6
 edx-opaque-keys==2.0.1
 edx-rest-api-client==3.0.2
 git+https://github.com/edx/credentials-themes.git@0.1.30#egg=edx_credentials_themes==0.1.30
 future==0.18.2            # via pyjwkest
 idna==2.7                 # via requests
 itypes==1.1.0             # via coreapi
-jinja2==2.11.0            # via coreschema
-markdown==3.1.1
+jinja2==2.11.1            # via coreschema
+markdown==3.2
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6
-newrelic==5.4.1.134
+newrelic==5.6.0.135
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 olefile==0.46             # via pillow
 openapi-codec==1.3.2      # via django-rest-swagger
+pbr==5.4.4                # via stevedore
 pillow==4.0.0
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
-pycryptodomex==3.9.4      # via pyjwkest
+pycryptodomex==3.9.6      # via pyjwkest
 pygments==2.5.2
-pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
+pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via analytics-python, edx-ace, edx-drf-extensions
@@ -67,8 +69,8 @@ semantic-version==2.8.4   # via edx-drf-extensions
 simplejson==3.17.0        # via django-rest-swagger, sailthru-client
 six==1.14.0
 slumber==0.7.1            # via edx-rest-api-client
-social-auth-app-django==1.2.0  # via edx-auth-backends
-social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
+social-auth-app-django==3.1.0  # via edx-auth-backends
+social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
 sqlparse==0.3.0           # via django-debug-toolbar
 stevedore==1.10.0         # via edx-ace, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,3 +31,6 @@ docker-compose >= 1.5.1
 # Version pins required to retain quality-check behavior
 edx-lint==0.5.5
 isort==4.2.5
+
+# django-storages version 1.9 drops support for boto storage backend.
+django-storages<1.9

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 analytics-python==1.2.9
 argparse==1.4.0
 astroid==1.5.2
@@ -12,7 +13,7 @@ bcrypt==3.1.7             # via paramiko
 bok-choy==1.0.1
 cached-property==1.5.1    # via docker-compose
 certifi==2019.11.28
-cffi==1.13.2              # via bcrypt, cryptography, pynacl
+cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4
 click-log==0.1.8
 click==7.0
@@ -25,29 +26,28 @@ defusedxml==0.6.0
 django-appconf==1.0.3
 django-compat==1.0.15
 django-debug-toolbar==1.6
-django-extensions==2.2.6
+django-extensions==2.2.8
 django-filter==1.0.4
 django-hijack==2.1.10
-django-ratelimit==2.0.0
 django-rest-swagger==2.2.0
 django-sortedm2m==3.0.0
 django-statici18n==1.9.0
 django-storages==1.8
 django-waffle==0.19.0
 django-webpack-loader==0.6.0
-django==1.11.27
+django==1.11.28
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
-docker-compose==1.25.3
-docker[ssh]==4.1.0        # via docker-compose
+docker-compose==1.25.4
+docker[ssh]==4.2.0        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 edx-ace==0.1.12
-edx-auth-backends==2.0.2
+edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
-edx-django-utils==2.0.3
-edx-drf-extensions==2.4.5
+edx-django-utils==2.0.4
+edx-drf-extensions==2.4.6
 edx-i18n-tools==0.5.0
 edx-lint==0.5.5
 edx-opaque-keys==2.0.1
@@ -61,17 +61,17 @@ idna==2.7
 importlib-metadata==1.5.0
 isort==4.2.5
 itypes==1.1.0
-jinja2==2.11.0
+jinja2==2.11.1
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3
 lazy==1.4
-markdown==3.1.1
+markdown==3.2
 markupsafe==1.1.1
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==8.2.0
 mysqlclient==1.4.6
-newrelic==5.4.1.134
+newrelic==5.6.0.135
 oauthlib==3.1.0
 olefile==0.46
 openapi-codec==1.3.2
@@ -87,7 +87,7 @@ polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
 py==1.8.1
 pycparser==2.19           # via cffi
-pycryptodomex==3.9.4
+pycryptodomex==3.9.6
 pygments==2.5.2
 pyinotify==0.9.6 ; "linux" in sys_platform
 pyjwkest==1.3.2
@@ -118,11 +118,11 @@ semantic-version==2.8.4
 simplejson==3.17.0
 six==1.14.0
 slumber==0.7.1
-social-auth-app-django==1.2.0
-social-auth-core[openidconnect]==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sqlparse==0.3.0
 stevedore==1.10.0
-testfixtures==6.11.0
+testfixtures==6.12.0
 text-unidecode==1.3
 texttable==1.6.2          # via docker-compose
 transifex-client==0.13.7

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,10 +6,13 @@
 #
 alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
+certifi==2019.11.28       # via requests
+chardet==3.0.4            # via requests
 docutils==0.16            # via sphinx
 edx-sphinx-theme==1.5.0
+idna==2.7                 # via requests
 imagesize==1.2.0          # via sphinx
-jinja2==2.11.0            # via sphinx
+jinja2==2.11.1            # via sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==20.1           # via sphinx
 pygments==2.5.2           # via sphinx
@@ -18,13 +21,14 @@ pytz==2019.3              # via babel
 requests==2.20.1          # via sphinx
 six==1.14.0               # via edx-sphinx-theme, packaging
 snowballstemmer==2.0.0    # via sphinx
-sphinx==2.3.1
+sphinx==2.4.0
 sphinxcontrib-applehelp==1.0.1  # via sphinx
 sphinxcontrib-devhelp==1.0.1  # via sphinx
 sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
+urllib3==1.24.3           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==4.4.0
+pip-tools==4.4.1
 six==1.14.0               # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,8 +4,9 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 analytics-python==1.2.9
-argparse==1.4.0           # via stevedore
+argparse==1.4.0
 attrs==17.4.0
 boto==2.49.0
 certifi==2019.11.28
@@ -16,10 +17,9 @@ defusedxml==0.6.0
 django-appconf==1.0.3
 django-compat==1.0.15
 django-debug-toolbar==1.6
-django-extensions==2.2.6
+django-extensions==2.2.8
 django-filter==1.0.4
 django-hijack==2.1.10
-django-ratelimit==2.0.0
 django-rest-swagger==2.2.0
 django-ses==0.8.14
 django-sortedm2m==3.0.0
@@ -27,15 +27,15 @@ django-statici18n==1.9.0
 django-storages==1.8
 django-waffle==0.19.0
 django-webpack-loader==0.6.0
-django==1.11.27
+django==1.11.28
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
 edx-ace==0.1.12
-edx-auth-backends==2.0.2
+edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
-edx-django-utils==2.0.3
-edx-drf-extensions==2.4.5
+edx-django-utils==2.0.4
+edx-drf-extensions==2.4.6
 edx-opaque-keys==2.0.1
 edx-rest-api-client==3.0.2
 git+https://github.com/edx/credentials-themes.git@0.1.30#egg=edx_credentials_themes==0.1.30
@@ -45,19 +45,19 @@ greenlet==0.4.15          # via gevent
 gunicorn==20.0.4
 idna==2.7
 itypes==1.1.0
-jinja2==2.11.0
-markdown==3.1.1
+jinja2==2.11.1
+markdown==3.2
 markupsafe==1.1.1
 mysqlclient==1.4.6
-newrelic==5.4.1.134
-nodeenv==1.3.4
+newrelic==5.6.0.135
+nodeenv==1.3.5
 oauthlib==3.1.0
 olefile==0.46
 openapi-codec==1.3.2
-pbr==5.4.4                # via stevedore
+pbr==5.4.4
 pillow==4.0.0
 psutil==1.2.1
-pycryptodomex==3.9.4
+pycryptodomex==3.9.6
 pygments==2.5.2
 pyjwkest==1.3.2
 pyjwt==1.7.1
@@ -75,8 +75,8 @@ semantic-version==2.8.4
 simplejson==3.17.0
 six==1.14.0
 slumber==0.7.1
-social-auth-app-django==1.2.0
-social-auth-core[openidconnect]==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sqlparse==0.3.0
 stevedore==1.10.0
 uritemplate==3.0.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,8 +4,9 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 analytics-python==1.2.9
-argparse==1.4.0           # via stevedore
+argparse==1.4.0
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery
 attrs==17.4.0
 bok-choy==1.0.1
@@ -21,25 +22,24 @@ defusedxml==0.6.0
 django-appconf==1.0.3
 django-compat==1.0.15
 django-debug-toolbar==1.6
-django-extensions==2.2.6
+django-extensions==2.2.8
 django-filter==1.0.4
 django-hijack==2.1.10
-django-ratelimit==2.0.0
 django-rest-swagger==2.2.0
 django-sortedm2m==3.0.0
 django-statici18n==1.9.0
 django-storages==1.8
 django-waffle==0.19.0
 django-webpack-loader==0.6.0
-django==1.11.27
+django==1.11.28
 djangorestframework-jwt==1.11.0
 djangorestframework==3.11.0
 edx-ace==0.1.12
-edx-auth-backends==2.0.2
+edx-auth-backends==3.0.2
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
-edx-django-utils==2.0.3
-edx-drf-extensions==2.4.5
+edx-django-utils==2.0.4
+edx-drf-extensions==2.4.6
 edx-lint==0.5.5
 edx-opaque-keys==2.0.1
 edx-rest-api-client==3.0.2
@@ -52,28 +52,28 @@ idna==2.7
 importlib-metadata==1.5.0  # via pluggy, pytest
 isort==4.2.5
 itypes==1.1.0
-jinja2==2.11.0
+jinja2==2.11.1
 lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via bok-choy
-markdown==3.1.1
+markdown==3.2
 markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==8.2.0     # via pytest
 mysqlclient==1.4.6
-newrelic==5.4.1.134
+newrelic==5.6.0.135
 oauthlib==3.1.0
 olefile==0.46
 openapi-codec==1.3.2
 packaging==20.1           # via pytest
 pathlib2==2.3.5           # via pytest
-pbr==5.4.4                # via stevedore
+pbr==5.4.4
 pep8==1.7.1
 pillow==4.0.0
 pluggy==0.13.1            # via pytest
 psutil==1.2.1
 py==1.8.1                 # via pytest
-pycryptodomex==3.9.4
+pycryptodomex==3.9.6
 pygments==2.5.2
 pyjwkest==1.3.2
 pyjwt==1.7.1
@@ -100,11 +100,11 @@ semantic-version==2.8.4
 simplejson==3.17.0
 six==1.14.0
 slumber==0.7.1
-social-auth-app-django==1.2.0
-social-auth-core[openidconnect]==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sqlparse==0.3.0
 stevedore==1.10.0
-testfixtures==6.11.0
+testfixtures==6.12.0
 text-unidecode==1.3       # via faker
 uritemplate==3.0.1
 urllib3==1.24.3


### PR DESCRIPTION
Relevant JIRA issue can be found [here](https://openedx.atlassian.net/browse/BOM-1259).
This PR also contains changes for `edx-auth-backends` (JIRA issue [here](https://openedx.atlassian.net/browse/BOM-1266)) upgrade.