### PR TITLE
Removing use of BearerAuthentication

### DIFF
--- a/credentials/apps/api/authentication.py
+++ b/credentials/apps/api/authentication.py
@@ -6,7 +6,6 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.models import Group
-from edx_rest_framework_extensions.auth.bearer.authentication import BearerAuthentication as BaseBearerAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
@@ -63,18 +62,3 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             user.groups.remove(admin_group)
 
         return user
-
-
-class BearerAuthentication(BaseBearerAuthentication):
-    """
-    Simple token based authentication.
-
-    This authentication class is useful for authenticating an OAuth2 access token against a remote
-    authentication provider. Clients should authenticate by passing the token key in the "Authorization" HTTP header,
-    prepended with the string `"Bearer "`.
-
-    NOTE: This authentication class is deprecated, see ARCH-396.
-    """
-    def get_user_info_url(self):
-        """ Returns the URL, hosted by the OAuth2 provider, from which user information can be pulled. """
-        return '{base}/user_info/'.format(base=settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL)

--- a/credentials/apps/api/authentication.py
+++ b/credentials/apps/api/authentication.py
@@ -4,7 +4,6 @@ Authentication logic for REST API.
 
 import logging
 
-from django.conf import settings
 from django.contrib.auth.models import Group
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication

--- a/credentials/apps/api/tests/test_authentication.py
+++ b/credentials/apps/api/tests/test_authentication.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.test import APIRequestFactory
 
-from credentials.apps.api.authentication import BearerAuthentication, JwtAuthentication, pipeline_set_user_roles
+from credentials.apps.api.authentication import JwtAuthentication, pipeline_set_user_roles
 from credentials.apps.api.tests.mixins import JwtMixin
 from credentials.apps.core.constants import Role
 from credentials.apps.core.tests.factories import UserFactory
@@ -119,33 +119,3 @@ class TestPipelineUserRoles(TestCase):
         """
         result = pipeline_set_user_roles({}, None)
         self.assertEqual(result, {})
-
-
-class BearerAuthenticationTests(TestCase):
-    """ Tests for the BearerAuthentication class. """
-
-    def setUp(self):
-        super(BearerAuthenticationTests, self).setUp()
-        self.auth = BearerAuthentication()
-        self.factory = APIRequestFactory()
-
-    def _create_request(self, token='12345', token_name='Bearer'):
-        """Create request with authorization header. """
-        auth_header = '{} {}'.format(token_name, token)
-        request = self.factory.get('/', HTTP_AUTHORIZATION=auth_header)
-        return request
-
-    def test_authenticate_header(self):
-        """The method should return the string Bearer."""
-        self.assertEqual(self.auth.authenticate_header(self._create_request()), 'Bearer')
-
-    def test_authenticate_invalid_token(self):
-        """If no token is supplied, or if the token contains spaces, the method should raise an exception."""
-
-        # Missing token
-        request = self._create_request('')
-        self.assertRaises(AuthenticationFailed, self.auth.authenticate, request)
-
-        # Token with spaces
-        request = self._create_request('abc 123 456')
-        self.assertRaises(AuthenticationFailed, self.auth.authenticate, request)

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -391,7 +391,6 @@ LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'credentials.apps.api.authentication.JwtAuthentication',
-        'credentials.apps.api.authentication.BearerAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),


### PR DESCRIPTION
According to our investigation using new relic custom metrics, BearerAuthentication class is not used and is safe for removal.

[PR that adds metric](https://github.com/edx/edx-drf-extensions/pull/105)