### PR TITLE
Allow edx-ace to be upgraded by unpinning attrs

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -9,7 +9,7 @@ analytics-python==1.2.9   # via -r requirements/dev.txt, -r requirements/product
 appdirs==1.4.3            # via -r requirements/dev.txt, virtualenv
 argparse==1.4.0           # via -r requirements/dev.txt, -r requirements/production.txt, stevedore
 astroid==2.3.3            # via -r requirements/dev.txt, pylint, pylint-celery
-attrs==17.4.0             # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, edx-ace, jsonschema, pytest
+attrs==19.3.0             # via -r requirements/dev.txt, -r requirements/production.txt, edx-ace, jsonschema, pytest
 bcrypt==3.1.7             # via -r requirements/dev.txt, paramiko
 bok-choy==1.0.1           # via -r requirements/dev.txt
 boto==2.49.0              # via -r requirements/production.txt, django-ses
@@ -46,7 +46,7 @@ docker[ssh]==4.2.0        # via -r requirements/dev.txt, docker-compose
 dockerpty==0.4.1          # via -r requirements/dev.txt, docker-compose
 docopt==0.6.2             # via -r requirements/dev.txt, docker-compose
 drf-jwt==1.15.1           # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions
-edx-ace==0.1.13           # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt
+edx-ace==0.1.14           # via -r requirements/dev.txt, -r requirements/production.txt
 edx-auth-backends==3.0.2  # via -r requirements/dev.txt, -r requirements/production.txt
 edx-django-release-util==0.3.6  # via -r requirements/dev.txt, -r requirements/production.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/dev.txt, -r requirements/production.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=django-ratelimit  # via -r requirements/base.in
 analytics-python==1.2.9   # via -r requirements/base.in
 argparse==1.4.0           # via stevedore
-attrs==17.4.0             # via -c requirements/constraints.txt, edx-ace
+attrs==19.3.0             # via edx-ace
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via -r requirements/base.in, django-rest-swagger, openapi-codec
@@ -28,7 +28,7 @@ django-webpack-loader==0.7.0  # via -r requirements/base.in
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-appconf, django-debug-toolbar, django-filter, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, rest-condition, xss-utils
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.15.1           # via edx-drf-extensions
-edx-ace==0.1.13           # via -c requirements/constraints.txt, -r requirements/base.in
+edx-ace==0.1.14           # via -r requirements/base.in
 edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,8 +12,7 @@
 # as a production requirement to avoid conflicts.
 pyyaml==3.12
 
-# Required to resolve requirements from base.in with inherited files 
-attrs==17.4.0
+# Required to resolve requirements from base.in with inherited files
 pillow==4.0.0
 requests==2.20.1
 stevedore==1.10.0
@@ -30,6 +29,3 @@ isort==4.2.5
 
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9
-
-# the changes done as part of 0.1.14 seems to have broken credentials tests
-edx-ace==0.1.13

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@ analytics-python==1.2.9   # via -r requirements/test.txt
 appdirs==1.4.3            # via -r requirements/test.txt, virtualenv
 argparse==1.4.0           # via -r requirements/test.txt, stevedore
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==17.4.0             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-ace, jsonschema, pytest
+attrs==19.3.0             # via -r requirements/test.txt, edx-ace, jsonschema, pytest
 bcrypt==3.1.7             # via paramiko
 bok-choy==1.0.1           # via -r requirements/test.txt
 cached-property==1.5.1    # via docker-compose
@@ -44,7 +44,7 @@ docker[ssh]==4.2.0        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 drf-jwt==1.15.1           # via -r requirements/test.txt, edx-drf-extensions
-edx-ace==0.1.13           # via -c requirements/constraints.txt, -r requirements/test.txt
+edx-ace==0.1.14           # via -r requirements/test.txt
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,7 +7,7 @@
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=django-ratelimit  # via -r requirements/base.txt
 analytics-python==1.2.9   # via -r requirements/base.txt
 argparse==1.4.0           # via -r requirements/base.txt, stevedore
-attrs==17.4.0             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-ace
+attrs==19.3.0             # via -r requirements/base.txt, edx-ace
 boto==2.49.0              # via -r requirements/production.in, django-ses
 certifi==2019.11.28       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -30,7 +30,7 @@ django-webpack-loader==0.7.0  # via -r requirements/base.txt
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-debug-toolbar, django-filter, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, rest-condition, xss-utils
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.15.1           # via -r requirements/base.txt, edx-drf-extensions
-edx-ace==0.1.13           # via -c requirements/constraints.txt, -r requirements/base.txt
+edx-ace==0.1.14           # via -r requirements/base.txt
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,7 +9,7 @@ analytics-python==1.2.9   # via -r requirements/base.txt
 appdirs==1.4.3            # via virtualenv
 argparse==1.4.0           # via -r requirements/base.txt, stevedore
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==17.4.0             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-ace, pytest
+attrs==19.3.0             # via -r requirements/base.txt, edx-ace, pytest
 bok-choy==1.0.1           # via -r requirements/test.in
 certifi==2019.11.28       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -35,7 +35,7 @@ django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-
 django-webpack-loader==0.7.0  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.15.1           # via -r requirements/base.txt, edx-drf-extensions
-edx-ace==0.1.13           # via -c requirements/constraints.txt, -r requirements/base.txt
+edx-ace==0.1.14           # via -r requirements/base.txt
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.txt


### PR DESCRIPTION
`edx-ace` was pinned [here](https://github.com/edx/credentials/pull/754/commits/86c7ec1a167a2776f9da29719fb69b4b68e4548a) by @dianakhuang because installing `edx-ace` alongside an older version of `attrs` broke tests.

This happened because I didn't realize that [my `edx-ace` change](https://github.com/edx/edx-ace/commit/6b203f7280d038447328094649b58862f0abe794) wasn't compatible with older versions of `attrs`, and didn't add a constraint to its `setup.py`.

I don't think pinning `attrs` to an old version for credentials was necessary in the first place, so this PR unpins it so that we can install the newest version of `edx-ace`.

@schenedx Please review when you have a chance.