### PR TITLE
run linter on all systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,5 +174,4 @@ upgrade: piptools ## update the requirements/*.txt files with the latest package
 	mv requirements/test.tmp requirements/test.txt
 
 check_keywords: ## Scan the Django models in all installed apps in this project for restricted field names
-	python manage.py check_reserved_keywords --override_file db_keyword_overrides.yml --report_file stich_keyword_report.csv --system STITCH
-	python manage.py check_reserved_keywords --override_file db_keyword_overrides.yml --report_file snowflake_keyword_report.csv --system SNOWFLAKE
+	python manage.py check_reserved_keywords --override_file db_keyword_overrides.yml

--- a/db_keyword_overrides.yml
+++ b/db_keyword_overrides.yml
@@ -6,5 +6,8 @@
 #   - ModelName.field_name
 ---
 MYSQL:
+   - CourseRun.key
+   - Organization.key
+   - Course.key
 SNOWFLAKE:
 STITCH:


### PR DESCRIPTION
I have enabled the reserved keyword linter to run for all of the default database systems (MYSQL, SNOWFLAKE, STITCH). This entailed adding any current keyword violations to the override file as to not fail CI.
---

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
