### PR TITLE
Address EDUCATOR-4716: Backend

### DIFF
--- a/credentials/settings/production.py
+++ b/credentials/settings/production.py
@@ -29,7 +29,7 @@ AWS_SES_REGION_ENDPOINT = environ.get('AWS_SES_REGION_ENDPOINT', 'email.us-east-
 
 CONFIG_FILE = get_env_setting('CREDENTIALS_CFG')
 with open(CONFIG_FILE, encoding='utf-8') as f:
-    config_from_yaml = yaml.load(f)
+    config_from_yaml = yaml.safe_load(f)
 
     # Remove the items that should be used to update dicts, and apply them separately rather
     # than pumping them into the local vars.

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -41,7 +41,7 @@ django-waffle==0.20.0     # via -r requirements/dev.txt, -r requirements/product
 django-webpack-loader==0.7.0  # via -r requirements/dev.txt, -r requirements/production.txt
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, django-appconf, django-debug-toolbar, django-filter, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, xss-utils
 djangorestframework==3.11.0  # via -r requirements/dev.txt, -r requirements/production.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-docker-compose==1.25.4    # via -c requirements/constraints.txt, -r requirements/dev.txt
+docker-compose==1.25.5    # via -c requirements/constraints.txt, -r requirements/dev.txt
 docker[ssh]==4.2.0        # via -r requirements/dev.txt, docker-compose
 dockerpty==0.4.1          # via -r requirements/dev.txt, docker-compose
 docopt==0.6.2             # via -r requirements/dev.txt, docker-compose
@@ -50,7 +50,7 @@ edx-ace==0.1.14           # via -r requirements/dev.txt, -r requirements/product
 edx-auth-backends==3.0.2  # via -r requirements/dev.txt, -r requirements/production.txt
 edx-django-release-util==0.4.2  # via -r requirements/dev.txt, -r requirements/production.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/dev.txt, -r requirements/production.txt
-edx-django-utils==3.1     # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.0   # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/dev.txt, -r requirements/production.txt
 edx-i18n-tools==0.5.0     # via -r requirements/dev.txt
 edx-lint==1.4.1           # via -r requirements/dev.txt
@@ -61,7 +61,7 @@ factory-boy==2.12.0       # via -r requirements/dev.txt
 faker==4.0.2              # via -r requirements/dev.txt, factory-boy
 filelock==3.0.12          # via -r requirements/dev.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/dev.txt, -r requirements/production.txt, django-ses, pyjwkest
-gevent==1.4.0             # via -r requirements/production.txt
+gevent==1.5.0             # via -r requirements/production.txt
 greenlet==0.4.15          # via -r requirements/production.txt, gevent
 gunicorn==20.0.4          # via -r requirements/production.txt
 httpretty==1.0.2          # via -r requirements/dev.txt
@@ -83,7 +83,6 @@ mysqlclient==1.4.6        # via -r requirements/dev.txt, -r requirements/product
 newrelic==5.10.0.138      # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
 nodeenv==1.3.5            # via -r requirements/production.txt
 oauthlib==3.1.0           # via -r requirements/dev.txt, -r requirements/production.txt, requests-oauthlib, social-auth-core
-olefile==0.46             # via -r requirements/dev.txt, -r requirements/production.txt, pillow
 openapi-codec==1.3.2      # via -r requirements/dev.txt, -r requirements/production.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/dev.txt, pytest, tox
 paramiko==2.7.1           # via -r requirements/dev.txt, docker
@@ -91,7 +90,7 @@ path.py==12.0.2           # via -c requirements/constraints.txt, -r requirements
 pathlib2==2.3.5           # via -r requirements/dev.txt, pytest
 pbr==5.4.5                # via -r requirements/dev.txt, -r requirements/production.txt, stevedore
 pep8==1.7.1               # via -r requirements/dev.txt
-pillow==4.0.0             # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt
+pillow==7.1.1             # via -r requirements/dev.txt, -r requirements/production.txt
 pluggy==0.13.1            # via -r requirements/dev.txt, pytest, tox
 polib==1.1.0              # via -r requirements/dev.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
@@ -117,7 +116,7 @@ python-memcached==1.59    # via -r requirements/dev.txt, -r requirements/product
 python-slugify==1.2.6     # via -r requirements/dev.txt, transifex-client
 python3-openid==3.1.0     # via -r requirements/dev.txt, -r requirements/production.txt, social-auth-core
 pytz==2019.3              # via -r requirements/dev.txt, -r requirements/production.txt, django, django-ses
-pyyaml==3.12              # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, docker-compose, edx-django-release-util, edx-i18n-tools
+pyyaml==5.3.1             # via -r requirements/dev.txt, -r requirements/production.txt, docker-compose, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/dev.txt, -r requirements/production.txt, social-auth-core
 requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, analytics-python, coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core, transifex-client
 responses==0.10.12        # via -r requirements/dev.txt
@@ -142,7 +141,7 @@ typed-ast==1.4.1          # via -r requirements/dev.txt, astroid
 unidecode==1.1.1          # via -r requirements/dev.txt, python-slugify
 uritemplate==3.0.1        # via -r requirements/dev.txt, -r requirements/production.txt, coreapi
 urllib3==1.24.3           # via -r requirements/dev.txt, -r requirements/production.txt, requests, selenium, transifex-client
-virtualenv==20.0.16       # via -r requirements/dev.txt, tox
+virtualenv==20.0.17       # via -r requirements/dev.txt, tox
 wcwidth==0.1.9            # via -r requirements/dev.txt, pytest
 websocket-client==0.57.0  # via -r requirements/dev.txt, docker, docker-compose
 wrapt==1.11.2             # via -r requirements/dev.txt, astroid

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ edx-ace==0.1.14           # via -r requirements/base.in
 edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.4.2  # via -r requirements/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.in
-edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
 edx-rest-api-client==5.1.0  # via -r requirements/base.in
@@ -46,10 +46,9 @@ markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6        # via -r requirements/base.in
 newrelic==5.10.0.138      # via -r requirements/base.in, edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
-olefile==0.46             # via pillow
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore
-pillow==4.0.0             # via -c requirements/constraints.txt, -r requirements/base.in
+pillow==7.1.1             # via -r requirements/base.in
 psutil==1.2.1             # via edx-django-utils
 pycryptodomex==3.9.7      # via pyjwkest
 pygments==2.6.1           # via -r requirements/base.in
@@ -60,7 +59,7 @@ python-dateutil==2.8.1    # via analytics-python, edx-ace, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/base.in
 python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3              # via -r requirements/base.in, django
-pyyaml==3.12              # via -c requirements/constraints.txt, edx-django-release-util
+pyyaml==5.3.1             # via edx-django-release-util
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/base.in, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, sailthru-client, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,12 +8,7 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# In order to get this OEP-18 compliant, pinning PyYaml to the version specified
-# as a production requirement to avoid conflicts.
-pyyaml==3.12
-
 # Required to resolve requirements from base.in with inherited files
-pillow==4.0.0
 requests==2.20.1
 stevedore==1.10.0
 path.py==12.0.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,7 +39,7 @@ django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-
 django-webpack-loader==0.7.0  # via -r requirements/test.txt
 django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt, django-appconf, django-debug-toolbar, django-filter, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, xss-utils
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
-docker-compose==1.25.4    # via -c requirements/constraints.txt, -r requirements/dev.in
+docker-compose==1.25.5    # via -c requirements/constraints.txt, -r requirements/dev.in
 docker[ssh]==4.2.0        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
@@ -48,7 +48,7 @@ edx-ace==0.1.14           # via -r requirements/test.txt
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.4.2  # via -r requirements/test.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/test.txt
-edx-django-utils==3.1     # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.0   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/test.txt
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-lint==1.4.1           # via -r requirements/test.txt
@@ -77,7 +77,6 @@ more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/test.txt
 newrelic==5.10.0.138      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
-olefile==0.46             # via -r requirements/test.txt, pillow
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/test.txt, pytest, tox
 paramiko==2.7.1           # via docker
@@ -85,7 +84,7 @@ path.py==12.0.2           # via -c requirements/constraints.txt, edx-i18n-tools
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pep8==1.7.1               # via -r requirements/test.txt
-pillow==4.0.0             # via -c requirements/constraints.txt, -r requirements/test.txt
+pillow==7.1.1             # via -r requirements/test.txt
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
@@ -111,7 +110,7 @@ python-memcached==1.59    # via -r requirements/test.txt
 python-slugify==1.2.6     # via transifex-client
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
 pytz==2019.3              # via -r requirements/test.txt, django
-pyyaml==3.12              # via -c requirements/constraints.txt, -r requirements/test.txt, docker-compose, edx-django-release-util, edx-i18n-tools
+pyyaml==5.3.1             # via -r requirements/test.txt, docker-compose, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/test.txt, analytics-python, coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core, transifex-client
 responses==0.10.12        # via -r requirements/test.txt
@@ -136,7 +135,7 @@ typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 unidecode==1.1.1          # via python-slugify
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.24.3           # via -r requirements/test.txt, requests, selenium, transifex-client
-virtualenv==20.0.16       # via -r requirements/test.txt, tox
+virtualenv==20.0.17       # via -r requirements/test.txt, tox
 wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.11.2             # via -r requirements/test.txt, astroid

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -21,7 +21,7 @@ pytz==2019.3              # via babel
 requests==2.20.1          # via -c requirements/constraints.txt, sphinx
 six==1.14.0               # via edx-sphinx-theme, packaging
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.0             # via -r requirements/docs.in, edx-sphinx-theme
+sphinx==3.0.1             # via -r requirements/docs.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -34,13 +34,13 @@ edx-ace==0.1.14           # via -r requirements/base.txt
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.4.2  # via -r requirements/base.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.txt
-edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.txt
 edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
 edx-rest-api-client==5.1.0  # via -r requirements/base.txt
 git+https://github.com/edx/credentials-themes.git@0.1.30#egg=edx_credentials_themes==0.1.30  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, django-ses, pyjwkest
-gevent==1.4.0             # via -r requirements/production.in
+gevent==1.5.0             # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.7                 # via -r requirements/base.txt, requests
@@ -52,10 +52,9 @@ mysqlclient==1.4.6        # via -r requirements/base.txt
 newrelic==5.10.0.138      # via -r requirements/base.txt, -r requirements/production.in, edx-django-utils
 nodeenv==1.3.5            # via -r requirements/production.in
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-olefile==0.46             # via -r requirements/base.txt, pillow
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
-pillow==4.0.0             # via -c requirements/constraints.txt, -r requirements/base.txt
+pillow==7.1.1             # via -r requirements/base.txt
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
 pygments==2.6.1           # via -r requirements/base.txt
@@ -66,7 +65,7 @@ python-dateutil==2.8.1    # via -r requirements/base.txt, analytics-python, edx-
 python-memcached==1.59    # via -r requirements/base.txt
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, django, django-ses
-pyyaml==3.12              # via -c requirements/constraints.txt, -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
+pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/base.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, sailthru-client, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -39,7 +39,7 @@ edx-ace==0.1.14           # via -r requirements/base.txt
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.4.2  # via -r requirements/base.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.txt
-edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.2.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==5.0.2  # via -r requirements/base.txt
 edx-lint==1.4.1           # via -r requirements/test.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
@@ -66,13 +66,12 @@ more-itertools==8.2.0     # via pytest
 mysqlclient==1.4.6        # via -r requirements/base.txt
 newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
-olefile==0.46             # via -r requirements/base.txt, pillow
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.3           # via pytest, tox
 pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pep8==1.7.1               # via -r requirements/test.in
-pillow==4.0.0             # via -c requirements/constraints.txt, -r requirements/base.txt
+pillow==7.1.1             # via -r requirements/base.txt
 pluggy==0.13.1            # via pytest, tox
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 py==1.8.1                 # via pytest, tox
@@ -92,7 +91,7 @@ python-dateutil==2.8.1    # via -r requirements/base.txt, analytics-python, edx-
 python-memcached==1.59    # via -r requirements/base.txt
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, django
-pyyaml==3.12              # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-release-util
+pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/base.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core
 responses==0.10.12        # via -r requirements/test.in
@@ -114,7 +113,7 @@ tox==3.14.6               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.24.3           # via -r requirements/base.txt, requests, selenium
-virtualenv==20.0.16       # via tox
+virtualenv==20.0.17       # via tox
 wcwidth==0.1.9            # via pytest
 wrapt==1.11.2             # via astroid
 xss-utils==0.1.2          # via -r requirements/base.txt


### PR DESCRIPTION
Please see https://openedx.atlassian.net/browse/EDUCATOR-4716

Most of the upgrades are to patch/minor versions, which I'm not worried about.

`pyyaml` was upgraded two major versions, but I'm familiar with the change-set and I feel comfortable with this upgrade.

`pillow` I am not familiar with, and it's been upgraded by three major versions. This is the one dependency upgrade that I'm not confident about.

@edx/masters-devs 