### PR TITLE
Import `private.py` into `devstack.py` 

### DIFF
--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -71,3 +71,10 @@ JWT_AUTH['JWT_ISSUERS'] = [
             'SECRET_KEY': 'lms-secret'
         }
     ]
+
+#####################################################################
+# Lastly, see if the developer has any local overrides.
+try:
+    from .private import *  # pylint: disable=import-error
+except ImportError:
+    pass


### PR DESCRIPTION
### Description

Imported the `private.py` file into `devstack.py` so that user using devstack can easily change their variables using `private.py`. Previously `private.py` was imported in `local.py` but `local.py` is not getting used anywhere so if user put anything into `private.py` it will not reflect in the settings.