### PR TITLE
Replaced deprecated method usage

### DIFF
--- a/credentials/apps/core/views.py
+++ b/credentials/apps/core/views.py
@@ -6,12 +6,13 @@ from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, login
 from django.db import DatabaseError, connection, transaction
 from django.http import Http404, JsonResponse
-from django.shortcuts import redirect, render_to_response
+from django.shortcuts import redirect, render
 from django.template import TemplateDoesNotExist
 from django.template.loader import select_template
 from django.views.generic import View
 
 from credentials.apps.core.constants import Status
+
 try:
     import newrelic.agent
 except ImportError:  # pragma: no cover
@@ -121,5 +122,4 @@ def render_500(request, template_name='500.html'):
     Arguments:
         template_name (template): Template for rendering
     """
-    response = render_to_response(template_name, status=500)
-    return response
+    return render(request, template_name, status=500)


### PR DESCRIPTION
Credentials Pull Request
---
`render_to_response` is removed in Django 3 ([ref](https://docs.djangoproject.com/en/3.0/releases/3.0/#features-removed-in-3-0)), this PR will replace `render_to_response` usage with `render`.
Relevant JIRA issue [here](https://openedx.atlassian.net/browse/BOM-1881)

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
