### PR TITLE
MST-316 Add the page full URL to GA events

### DIFF
--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -536,15 +536,10 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
             'page': {
                 'path': request.path,
                 'referrer': request.META.get('HTTP_REFERER'),
+                'url': request.build_absolute_uri(),
             },
             'userAgent': request.META.get('HTTP_USER_AGENT'),
         }
-
-        # Get page information, in part to provide hostname info.
-        if request.method == 'GET':
-            context['page']['url'] = request.GET.get('page')
-        elif request.method == 'POST':
-            context['page']['url'] = request.POST.get('page')
 
         segment_client.track(
             request.COOKIES.get('ajs_anonymous_id'),


### PR DESCRIPTION
Credentials Pull Request
---
https://openedx.atlassian.net/browse/MST-316
Adding the "url" property to GA events as part of the missing info needed on segment events.

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired

@edx/masters-devs-cosmonauts and @brianhw Please review