### PR TITLE
Python Requirements Update

### DIFF
--- a/credentials/apps/catalog/tests/factories.py
+++ b/credentials/apps/catalog/tests/factories.py
@@ -18,7 +18,7 @@ def add_m2m_data(m2m_relation, data):
         m2m_relation.add(*data)
 
 
-class OrganizationFactory(factory.DjangoModelFactory):
+class OrganizationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Organization
 
@@ -28,7 +28,7 @@ class OrganizationFactory(factory.DjangoModelFactory):
     name = FuzzyText(prefix="Test Org ")
 
 
-class CourseFactory(factory.DjangoModelFactory):
+class CourseFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Course
 
@@ -43,7 +43,7 @@ class CourseFactory(factory.DjangoModelFactory):
             add_m2m_data(self.owners, extracted)
 
 
-class CourseRunFactory(factory.DjangoModelFactory):
+class CourseRunFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CourseRun
 
@@ -55,7 +55,7 @@ class CourseRunFactory(factory.DjangoModelFactory):
     end_date = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC)).end_dt
 
 
-class ProgramFactory(factory.DjangoModelFactory):
+class ProgramFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Program
 
@@ -76,7 +76,7 @@ class ProgramFactory(factory.DjangoModelFactory):
             add_m2m_data(self.authoring_organizations, extracted)
 
 
-class PathwayFactory(factory.DjangoModelFactory):
+class PathwayFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Pathway
 

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -11,9 +11,9 @@ astroid==2.3.3            # via -r requirements/dev.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/dev.txt, -r requirements/production.txt, edx-ace, jsonschema, pytest
 bcrypt==3.1.7             # via -r requirements/dev.txt, paramiko
 bok-choy==1.1.1           # via -r requirements/dev.txt
-boto3==1.14.36            # via -r requirements/production.txt, django-ses
+boto3==1.14.42            # via -r requirements/production.txt, django-ses
 boto==2.49.0              # via -r requirements/production.txt
-botocore==1.17.36         # via -r requirements/production.txt, boto3, s3transfer
+botocore==1.17.42         # via -r requirements/production.txt, boto3, s3transfer
 cached-property==1.5.1    # via -r requirements/dev.txt, docker-compose
 certifi==2020.6.20        # via -r requirements/dev.txt, -r requirements/production.txt, requests
 cffi==1.14.1              # via -r requirements/dev.txt, -r requirements/production.txt, bcrypt, cryptography, pynacl
@@ -31,7 +31,7 @@ distro==1.5.0             # via -r requirements/dev.txt, docker-compose
 django-appconf==1.0.4     # via -r requirements/dev.txt, -r requirements/production.txt, django-statici18n
 django-compat==1.0.15     # via -r requirements/dev.txt, -r requirements/production.txt, django-hijack
 django-debug-toolbar==2.2  # via -r requirements/dev.txt, -r requirements/production.txt
-django-extensions==3.0.4  # via -r requirements/dev.txt, -r requirements/production.txt
+django-extensions==3.0.5  # via -r requirements/dev.txt, -r requirements/production.txt
 django-filter==2.3.0      # via -r requirements/dev.txt, -r requirements/production.txt
 django-hijack==2.1.10     # via -r requirements/dev.txt, -r requirements/production.txt
 django-ratelimit==3.0.1   # via -r requirements/dev.txt, -r requirements/production.txt
@@ -45,7 +45,7 @@ django-webpack-loader==0.7.0  # via -r requirements/dev.txt, -r requirements/pro
 django==2.2.15            # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, django-appconf, django-debug-toolbar, django-filter, django-ses, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, xss-utils
 djangorestframework==3.11.1  # via -r requirements/dev.txt, -r requirements/production.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 docker-compose==1.26.2    # via -c requirements/constraints.txt, -r requirements/dev.txt
-docker[ssh]==4.2.2        # via -r requirements/dev.txt, docker-compose
+docker[ssh]==4.3.0        # via -r requirements/dev.txt, docker-compose
 dockerpty==0.4.1          # via -r requirements/dev.txt, docker-compose
 docopt==0.6.2             # via -r requirements/dev.txt, docker-compose
 docutils==0.15.2          # via -r requirements/production.txt, botocore
@@ -54,14 +54,14 @@ edx-ace==0.1.15           # via -r requirements/dev.txt, -r requirements/product
 edx-auth-backends==3.1.0  # via -r requirements/dev.txt, -r requirements/production.txt
 edx-django-release-util==0.4.4  # via -r requirements/dev.txt, -r requirements/production.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/dev.txt, -r requirements/production.txt
-edx-django-utils==3.6.0   # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.7.3   # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/dev.txt, -r requirements/production.txt
 edx-i18n-tools==0.5.3     # via -r requirements/dev.txt
 edx-lint==1.5.0           # via -r requirements/dev.txt
 edx-opaque-keys==2.1.1    # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions
 edx-rest-api-client==5.2.1  # via -r requirements/dev.txt, -r requirements/production.txt
 git+https://github.com/edx/credentials-themes.git@0.1.30#egg=edx_credentials_themes==0.1.30  # via -r requirements/dev.txt, -r requirements/production.txt
-factory-boy==2.12.0       # via -r requirements/dev.txt
+factory-boy==3.0.1        # via -r requirements/dev.txt
 faker==4.1.1              # via -r requirements/dev.txt, factory-boy
 filelock==3.0.12          # via -r requirements/dev.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/dev.txt, -r requirements/production.txt, django-ses, pyjwkest
@@ -71,7 +71,7 @@ gitpython==3.1.7          # via -r requirements/dev.txt, transifex-client
 greenlet==0.4.16          # via -r requirements/production.txt, gevent
 gunicorn==20.0.4          # via -r requirements/production.txt
 httpretty==1.0.2          # via -r requirements/dev.txt
-idna==2.7                 # via -r requirements/dev.txt, -r requirements/production.txt, requests
+idna==2.10                # via -r requirements/dev.txt, -r requirements/production.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/dev.txt, -r requirements/production.txt, jsonschema, markdown, path.py, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/dev.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/dev.txt, pytest
@@ -85,10 +85,10 @@ lazy==1.4                 # via -r requirements/dev.txt, bok-choy
 markdown==3.2.2           # via -r requirements/dev.txt, -r requirements/production.txt
 markupsafe==1.1.1         # via -r requirements/dev.txt, -r requirements/production.txt, jinja2
 mccabe==0.6.1             # via -r requirements/dev.txt, pylint
-mock==3.0.5               # via -r requirements/dev.txt
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/dev.txt
 more-itertools==8.4.0     # via -r requirements/dev.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/dev.txt, -r requirements/production.txt
-newrelic==5.14.1.144      # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
+newrelic==5.16.0.145      # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
 nodeenv==1.4.0            # via -r requirements/production.txt
 oauthlib==3.1.0           # via -r requirements/dev.txt, -r requirements/production.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/dev.txt, -r requirements/production.txt, django-rest-swagger
@@ -101,7 +101,7 @@ pep8==1.7.1               # via -r requirements/dev.txt
 pillow==7.2.0             # via -r requirements/dev.txt, -r requirements/production.txt
 pluggy==0.13.1            # via -r requirements/dev.txt, pytest, tox
 polib==1.1.0              # via -r requirements/dev.txt, edx-i18n-tools
-psutil==1.2.1             # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/dev.txt, pytest, tox
 pycparser==2.20           # via -r requirements/dev.txt, -r requirements/production.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/dev.txt, -r requirements/production.txt, pyjwkest
@@ -127,8 +127,8 @@ pytz==2020.1              # via -r requirements/dev.txt, -r requirements/product
 pywatchman==1.4.1 ; "linux" in sys_platform  # via -r requirements/dev.txt
 pyyaml==5.3.1             # via -r requirements/dev.txt, -r requirements/production.txt, docker-compose, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/dev.txt, -r requirements/production.txt, social-auth-core
-requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, analytics-python, coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core, transifex-client
-responses==0.10.15        # via -r requirements/dev.txt
+requests==2.24.0          # via -r requirements/dev.txt, -r requirements/production.txt, analytics-python, coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core, transifex-client
+responses==0.10.16        # via -r requirements/dev.txt
 rest-condition==1.0.3     # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions
 s3transfer==0.3.3         # via -r requirements/production.txt, boto3
 sailthru-client==2.2.3    # via -r requirements/dev.txt, -r requirements/production.txt, edx-ace
@@ -141,21 +141,21 @@ smmap==3.0.4              # via -r requirements/dev.txt, gitdb
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/dev.txt, -r requirements/production.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/dev.txt, -r requirements/production.txt, django, django-debug-toolbar
-stevedore==1.10.0         # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, edx-ace, edx-opaque-keys
+stevedore==1.10.0         # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, edx-ace, edx-django-utils, edx-opaque-keys
 testfixtures==6.14.1      # via -r requirements/dev.txt
 text-unidecode==1.3       # via -r requirements/dev.txt, faker, python-slugify
 texttable==1.6.2          # via -r requirements/dev.txt, docker-compose
 toml==0.10.1              # via -r requirements/dev.txt, pytest, tox
-tox==3.18.1               # via -r requirements/dev.txt
+tox==3.19.0               # via -r requirements/dev.txt
 transifex-client==0.13.11  # via -r requirements/dev.txt
 typed-ast==1.4.1          # via -r requirements/dev.txt, astroid
 uritemplate==3.0.1        # via -r requirements/dev.txt, -r requirements/production.txt, coreapi
-urllib3==1.24.3           # via -r requirements/dev.txt, -r requirements/production.txt, botocore, requests, selenium, transifex-client
+urllib3==1.25.10          # via -r requirements/dev.txt, -r requirements/production.txt, botocore, requests, responses, selenium, transifex-client
 virtualenv==20.0.30       # via -r requirements/dev.txt, tox
 websocket-client==0.57.0  # via -r requirements/dev.txt, docker, docker-compose
 wrapt==1.11.2             # via -r requirements/dev.txt, astroid
 xss-utils==0.1.3          # via -r requirements/dev.txt, -r requirements/production.txt
-zipp==1.2.0               # via -r requirements/dev.txt, -r requirements/production.txt, importlib-metadata, importlib-resources
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, importlib-metadata, importlib-resources
 zope.event==4.4           # via -r requirements/production.txt, gevent
 zope.interface==5.1.0     # via -r requirements/production.txt, gevent
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,7 @@ defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-appconf==1.0.4     # via django-statici18n
 django-compat==1.0.15     # via django-hijack
 django-debug-toolbar==2.2  # via -r requirements/base.in
-django-extensions==3.0.4  # via -r requirements/base.in
+django-extensions==3.0.5  # via -r requirements/base.in
 django-filter==2.3.0      # via -r requirements/base.in
 django-hijack==2.1.10     # via -r requirements/base.in
 django-ratelimit==3.0.1   # via -r requirements/base.in
@@ -34,25 +34,25 @@ edx-ace==0.1.15           # via -r requirements/base.in
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
-edx-django-utils==3.6.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.7.3   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rest-api-client==5.2.1  # via -r requirements/base.in
 git+https://github.com/edx/credentials-themes.git@0.1.30#egg=edx_credentials_themes==0.1.30  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
-idna==2.7                 # via requests
+idna==2.10                # via requests
 importlib-metadata==1.7.0  # via markdown
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 markdown==3.2.2           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mysqlclient==2.0.1        # via -r requirements/base.in
-newrelic==5.14.1.144      # via -r requirements/base.in, edx-django-utils
+newrelic==5.16.0.145      # via -r requirements/base.in, edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore
 pillow==7.2.0             # via -r requirements/base.in
-psutil==1.2.1             # via edx-django-utils
+psutil==5.7.2             # via edx-django-utils
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pygments==2.6.1           # via -r requirements/base.in
@@ -65,7 +65,7 @@ python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, django
 pyyaml==5.3.1             # via edx-django-release-util
 requests-oauthlib==1.3.0  # via social-auth-core
-requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/base.in, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, sailthru-client, slumber, social-auth-core
+requests==2.24.0          # via -r requirements/base.in, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, sailthru-client, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
 sailthru-client==2.2.3    # via edx-ace
 semantic-version==2.8.5   # via edx-drf-extensions
@@ -75,8 +75,8 @@ slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via django, django-debug-toolbar
-stevedore==1.10.0         # via -c requirements/constraints.txt, edx-ace, edx-opaque-keys
+stevedore==1.10.0         # via -c requirements/constraints.txt, edx-ace, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via coreapi
-urllib3==1.24.3           # via requests
+urllib3==1.25.10          # via requests
 xss-utils==0.1.3          # via -r requirements/base.in
-zipp==1.2.0               # via importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,9 +9,12 @@
 # linking to it here is good.
 
 # Required to resolve requirements from base.in with inherited files
-requests==2.20.1
 stevedore==1.10.0
 path.py==12.0.2
+
+# Requires python 3.6
+mock<4.0.0
+zipp<2.0.0
 
 # Remaining version pins to maintain behavior in
 Django<2.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ distro==1.5.0             # via docker-compose
 django-appconf==1.0.4     # via -r requirements/test.txt, django-statici18n
 django-compat==1.0.15     # via -r requirements/test.txt, django-hijack
 django-debug-toolbar==2.2  # via -r requirements/test.txt
-django-extensions==3.0.4  # via -r requirements/test.txt
+django-extensions==3.0.5  # via -r requirements/test.txt
 django-filter==2.3.0      # via -r requirements/test.txt
 django-hijack==2.1.10     # via -r requirements/test.txt
 django-ratelimit==3.0.1   # via -r requirements/test.txt
@@ -41,7 +41,7 @@ django-webpack-loader==0.7.0  # via -r requirements/test.txt
 django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt, django-appconf, django-debug-toolbar, django-filter, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, xss-utils
 djangorestframework==3.11.1  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 docker-compose==1.26.2    # via -c requirements/constraints.txt, -r requirements/dev.in
-docker[ssh]==4.2.2        # via docker-compose
+docker[ssh]==4.3.0        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 drf-jwt==1.16.2           # via -r requirements/test.txt, edx-drf-extensions
@@ -49,21 +49,21 @@ edx-ace==0.1.15           # via -r requirements/test.txt
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/test.txt
-edx-django-utils==3.6.0   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.7.3   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.0           # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rest-api-client==5.2.1  # via -r requirements/test.txt
 git+https://github.com/edx/credentials-themes.git@0.1.30#egg=edx_credentials_themes==0.1.30  # via -r requirements/test.txt
-factory-boy==2.12.0       # via -r requirements/test.txt
+factory-boy==3.0.1        # via -r requirements/test.txt
 faker==4.1.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.7          # via transifex-client
 httpretty==1.0.2          # via -r requirements/test.txt
-idna==2.7                 # via -r requirements/test.txt, requests
+idna==2.10                # via -r requirements/test.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/test.txt, jsonschema, markdown, path.py, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
@@ -76,10 +76,10 @@ lazy==1.4                 # via -r requirements/test.txt, bok-choy
 markdown==3.2.2           # via -r requirements/test.txt
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mock==3.0.5               # via -r requirements/test.txt
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysqlclient==2.0.1        # via -r requirements/test.txt
-newrelic==5.14.1.144      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.16.0.145      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, pytest, tox
@@ -91,7 +91,7 @@ pep8==1.7.1               # via -r requirements/test.txt
 pillow==7.2.0             # via -r requirements/test.txt
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
@@ -117,8 +117,8 @@ pytz==2020.1              # via -r requirements/test.txt, django
 pywatchman==1.4.1 ; "linux" in sys_platform  # via -r requirements/dev.in
 pyyaml==5.3.1             # via -r requirements/test.txt, docker-compose, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
-requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/test.txt, analytics-python, coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core, transifex-client
-responses==0.10.15        # via -r requirements/test.txt
+requests==2.24.0          # via -r requirements/test.txt, analytics-python, coreapi, docker, docker-compose, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core, transifex-client
+responses==0.10.16        # via -r requirements/test.txt
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 sailthru-client==2.2.3    # via -r requirements/test.txt, edx-ace
 selenium==3.141.0         # via -r requirements/test.txt, bok-choy
@@ -130,21 +130,21 @@ smmap==3.0.4              # via gitdb
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/test.txt, django, django-debug-toolbar
-stevedore==1.10.0         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-ace, edx-opaque-keys
+stevedore==1.10.0         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-ace, edx-django-utils, edx-opaque-keys
 testfixtures==6.14.1      # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 texttable==1.6.2          # via docker-compose
 toml==0.10.1              # via -r requirements/test.txt, pytest, tox
-tox==3.18.1               # via -r requirements/test.txt
+tox==3.19.0               # via -r requirements/test.txt
 transifex-client==0.13.11  # via -r requirements/dev.in
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.24.3           # via -r requirements/test.txt, requests, selenium, transifex-client
+urllib3==1.25.10          # via -r requirements/test.txt, requests, responses, selenium, transifex-client
 virtualenv==20.0.30       # via -r requirements/test.txt, tox
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 xss-utils==0.1.3          # via -r requirements/test.txt
-zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,7 @@ certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 docutils==0.16            # via sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/docs.in
-idna==2.7                 # via requests
+idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
@@ -18,17 +18,17 @@ packaging==20.4           # via sphinx
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytz==2020.1              # via babel
-requests==2.20.1          # via -c requirements/constraints.txt, sphinx
+requests==2.24.0          # via sphinx
 six==1.15.0               # via edx-sphinx-theme, packaging
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.1.2             # via -r requirements/docs.in, edx-sphinx-theme
+sphinx==3.2.0             # via -r requirements/docs.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-urllib3==1.24.3           # via requests
+urllib3==1.25.10          # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,9 +7,9 @@
 analytics-python==1.2.9   # via -r requirements/base.txt
 argparse==1.4.0           # via -r requirements/base.txt, stevedore
 attrs==19.3.0             # via -r requirements/base.txt, edx-ace
-boto3==1.14.36            # via django-ses
+boto3==1.14.42            # via django-ses
 boto==2.49.0              # via -r requirements/production.in
-botocore==1.17.36         # via boto3, s3transfer
+botocore==1.17.42         # via boto3, s3transfer
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 cffi==1.14.1              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -20,7 +20,7 @@ defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social
 django-appconf==1.0.4     # via -r requirements/base.txt, django-statici18n
 django-compat==1.0.15     # via -r requirements/base.txt, django-hijack
 django-debug-toolbar==2.2  # via -r requirements/base.txt
-django-extensions==3.0.4  # via -r requirements/base.txt
+django-extensions==3.0.5  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-hijack==2.1.10     # via -r requirements/base.txt
 django-ratelimit==3.0.1   # via -r requirements/base.txt
@@ -39,7 +39,7 @@ edx-ace==0.1.15           # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.txt
-edx-django-utils==3.6.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rest-api-client==5.2.1  # via -r requirements/base.txt
@@ -48,7 +48,7 @@ future==0.18.2            # via -r requirements/base.txt, django-ses, pyjwkest
 gevent==20.6.2            # via -r requirements/production.in
 greenlet==0.4.16          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
-idna==2.7                 # via -r requirements/base.txt, requests
+idna==2.10                # via -r requirements/base.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/base.txt, markdown
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
@@ -56,13 +56,13 @@ jmespath==0.10.0          # via boto3, botocore
 markdown==3.2.2           # via -r requirements/base.txt
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.14.1.144      # via -r requirements/base.txt, -r requirements/production.in, edx-django-utils
+newrelic==5.16.0.145      # via -r requirements/base.txt, -r requirements/production.in, edx-django-utils
 nodeenv==1.4.0            # via -r requirements/production.in
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pillow==7.2.0             # via -r requirements/base.txt
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pygments==2.6.1           # via -r requirements/base.txt
@@ -75,7 +75,7 @@ python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, django, django-ses
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/base.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, sailthru-client, slumber, social-auth-core
+requests==2.24.0          # via -r requirements/base.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, sailthru-client, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 s3transfer==0.3.3         # via boto3
 sailthru-client==2.2.3    # via -r requirements/base.txt, edx-ace
@@ -86,11 +86,11 @@ slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django, django-debug-toolbar
-stevedore==1.10.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-ace, edx-opaque-keys
+stevedore==1.10.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-ace, edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.24.3           # via -r requirements/base.txt, botocore, requests
+urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
 xss-utils==0.1.3          # via -r requirements/base.txt
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -25,7 +25,7 @@ distlib==0.3.1            # via virtualenv
 django-appconf==1.0.4     # via -r requirements/base.txt, django-statici18n
 django-compat==1.0.15     # via -r requirements/base.txt, django-hijack
 django-debug-toolbar==2.2  # via -r requirements/base.txt
-django-extensions==3.0.4  # via -r requirements/base.txt
+django-extensions==3.0.5  # via -r requirements/base.txt
 django-filter==2.3.0      # via -r requirements/base.txt
 django-hijack==2.1.10     # via -r requirements/base.txt
 django-ratelimit==3.0.1   # via -r requirements/base.txt
@@ -41,18 +41,18 @@ edx-ace==0.1.15           # via -r requirements/base.txt
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.txt
-edx-django-utils==3.6.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.7.3   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt
 edx-lint==1.5.0           # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rest-api-client==5.2.1  # via -r requirements/base.txt
 git+https://github.com/edx/credentials-themes.git@0.1.30#egg=edx_credentials_themes==0.1.30  # via -r requirements/base.txt
-factory-boy==2.12.0       # via -r requirements/test.in
+factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.1              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 httpretty==1.0.2          # via -r requirements/test.in
-idna==2.7                 # via -r requirements/base.txt, requests
+idna==2.10                # via -r requirements/base.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/base.txt, markdown, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 iniconfig==1.0.1          # via pytest
@@ -64,10 +64,10 @@ lazy==1.4                 # via bok-choy
 markdown==3.2.2           # via -r requirements/base.txt
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -r requirements/test.in
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.4.0     # via pytest
 mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.16.0.145      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via pytest, tox
@@ -76,7 +76,7 @@ pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pep8==1.7.1               # via -r requirements/test.in
 pillow==7.2.0             # via -r requirements/base.txt
 pluggy==0.13.1            # via pytest, tox
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 py==1.9.0                 # via pytest, tox
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
@@ -97,8 +97,8 @@ python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, django
 pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.20.1          # via -c requirements/constraints.txt, -r requirements/base.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core
-responses==0.10.15        # via -r requirements/test.in
+requests==2.24.0          # via -r requirements/base.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core
+responses==0.10.16        # via -r requirements/test.in
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 sailthru-client==2.2.3    # via -r requirements/base.txt, edx-ace
 selenium==3.141.0         # via bok-choy
@@ -109,15 +109,15 @@ slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django, django-debug-toolbar
-stevedore==1.10.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-ace, edx-opaque-keys
+stevedore==1.10.0         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-ace, edx-django-utils, edx-opaque-keys
 testfixtures==6.14.1      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 toml==0.10.1              # via pytest, tox
-tox==3.18.1               # via -r requirements/test.in
+tox==3.19.0               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.24.3           # via -r requirements/base.txt, requests, selenium
+urllib3==1.25.10          # via -r requirements/base.txt, requests, responses, selenium
 virtualenv==20.0.30       # via tox
 wrapt==1.11.2             # via astroid
 xss-utils==0.1.3          # via -r requirements/base.txt
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
Updated pinned versions to fix failed python upgrade job:

- `mock` and `zipp` pinned due to `Python>=3.6` requirement
- `requests` unpinned as it no longer causes an upgrade issue

Fixed [bad import alias removed](https://factoryboy.readthedocs.io/en/latest/changelog.html#id2) in `factory-boy==3.x`