### PR TITLE
Update the Credentials program-listing endpoint to use Staff instead of

### DIFF
--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -255,7 +255,7 @@ class ProgramListingViewTests(SiteMixin, TestCase):
         super().setUp()
         dump_random_state()
 
-        self.user = UserFactory(username=self.MOCK_USER_DATA['username'], is_superuser=True)
+        self.user = UserFactory(username=self.MOCK_USER_DATA['username'], is_staff=True)
         self.orgs = [OrganizationFactory.create(name=name, site=self.site) for name in ['TestOrg1', 'TestOrg2']]
         self.course = CourseFactory.create(site=self.site)
         self.course_runs = CourseRunFactory.create_batch(2, course=self.course)
@@ -328,8 +328,8 @@ class ProgramListingViewTests(SiteMixin, TestCase):
         self.assertRegex(response.url, '^/login/.*')
 
     def test_only_superuser_access(self):
-        """ Verify that the view rejects non-superusers. """
-        self.user.is_superuser = False
+        """ Verify that the view rejects non-staff users. """
+        self.user.is_staff = False
         self.user.save()
         self._render_listing(status_code=404)
 

--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -359,8 +359,6 @@ class ProgramListingViewTests(SiteMixin, TestCase):
 
     def test_normal_access_as_staff(self):
         """ Verify that the view works in default case. Staff is set in the setup method."""
-        response = self._render_listing()
-        response_context_data = response.context_data
         self._verify_normal_access()
 
     @ddt.data(

--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -317,6 +317,17 @@ class ProgramListingViewTests(SiteMixin, TestCase):
 
         return data
 
+    def _verify_normal_access(self):
+        response = self._render_listing()
+        response_context_data = response.context_data
+
+        self.assertContains(response, 'Program Listing View')
+
+        actual_child_templates = response_context_data['child_templates']
+        self.assert_matching_template_origin(actual_child_templates['footer'], '_footer.html')
+        self.assert_matching_template_origin(actual_child_templates['header'], '_header.html')
+        self.assertNotIn('masquerade', actual_child_templates)  # no masquerading on this view
+
     def assert_matching_template_origin(self, actual, expected_template_name):
         expected = select_template([expected_template_name])
         self.assertEqual(actual.origin, expected.origin)
@@ -327,23 +338,30 @@ class ProgramListingViewTests(SiteMixin, TestCase):
         response = self._render_listing(status_code=302)
         self.assertRegex(response.url, '^/login/.*')
 
-    def test_only_superuser_access(self):
+    def test_non_superuser_access(self):
+        """ Verify that the view rejects non-superuser users. """
+        self.user.is_superuser = False
+        self.user.is_staff = False
+        self.user.save()
+        self._render_listing(status_code=404)
+
+    def test_only_staff_access(self):
         """ Verify that the view rejects non-staff users. """
         self.user.is_staff = False
         self.user.save()
         self._render_listing(status_code=404)
 
-    def test_normal_access(self):
-        """ Verify that the view works in default case. """
+    def test_normal_access_superuser(self):
+        """ Verify that the view works with only superuser, no staff. """
+        self.user.is_superuser = True
+        self.user.is_staff = False
+        self._verify_normal_access()
+
+    def test_normal_access_as_staff(self):
+        """ Verify that the view works in default case. Staff is set in the setup method."""
         response = self._render_listing()
         response_context_data = response.context_data
-
-        self.assertContains(response, 'Program Listing View')
-
-        actual_child_templates = response_context_data['child_templates']
-        self.assert_matching_template_origin(actual_child_templates['footer'], '_footer.html')
-        self.assert_matching_template_origin(actual_child_templates['header'], '_header.html')
-        self.assertNotIn('masquerade', actual_child_templates)  # no masquerading on this view
+        self._verify_normal_access()
 
     @ddt.data(
         (Program.ACTIVE, True),

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -316,8 +316,8 @@ class ProgramListingView(RecordsListBaseView):
         return context
 
     def dispatch(self, request, *args, **kwargs):
-        # Kick out non-superusers (skipping anonymous users, because they are redirected to a login screen instead)
-        if not request.user.is_anonymous and not request.user.is_superuser:
+        # Kick out non staff users (skipping anonymous users, because they are redirected to a login screen instead)
+        if not request.user.is_anonymous and not request.user.is_staff:
             raise http.Http404()
         return super().dispatch(request, *args, **kwargs)
 

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -316,8 +316,9 @@ class ProgramListingView(RecordsListBaseView):
         return context
 
     def dispatch(self, request, *args, **kwargs):
-        # Kick out non staff users (skipping anonymous users, because they are redirected to a login screen instead)
-        if not request.user.is_anonymous and not request.user.is_staff:
+        # Kick out non staff and non superuser users (skipping anonymous users,
+        # because they are redirected to a login screen instead)
+        if not request.user.is_anonymous and not request.user.is_staff and not request.user.is_superuser:
             raise http.Http404()
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
superuser

[MICROBA-598]

The Credentials endpoint program-listing/ was meant for the support
team and internal teams to use as a debugging tool. The user type
Superuser was improperly used and now that less internal users
have that role it is unusable. Changing this to the Django Staff role
will allow internal users to access the tool again.

Credentials Pull Request
---

Make sure that the following steps are done before rebasing/merging

  - [x] Request a review if desired
  - [x] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [x] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [x] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [x] Consider other browsers (e.g. Firefox)
    - [x] Check mobile view
    - [x] Consider accessibility (e.g. Run aXe on the page)
