### PR TITLE
MICROBA-521 | Fix default JWT issuer for development

### DIFF
--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -64,13 +64,23 @@ BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = os.environ.get(
 
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = str2bool(os.environ.get('SOCIAL_AUTH_REDIRECT_IS_HTTPS', False))
 
-JWT_AUTH['JWT_ISSUERS'] = [
-        {
-            'AUDIENCE': 'lms-key',
-            'ISSUER': 'http://127.0.0.1:8000/oauth2',
-            'SECRET_KEY': 'lms-secret'
-        }
-    ]
+JWT_AUTH.update({
+    'JWT_SECRET_KEY': 'lms-secret',
+    'JWT_ISSUER': 'http://localhost:18000/oauth2',
+    'JWT_AUDIENCE': None,
+    'JWT_VERIFY_AUDIENCE': False,
+    'JWT_PUBLIC_SIGNING_JWK_SET': (
+        '{"keys": [{"kid": "devstack_key", "e": "AQAB", "kty": "RSA", "n": "smKFSYowG6nNUAdeqH1jQQnH1PmIHphzBmwJ5vRf1vu'
+        '48BUI5VcVtUWIPqzRK_LDSlZYh9D0YFL0ZTxIrlb6Tn3Xz7pYvpIAeYuQv3_H5p8tbz7Fb8r63c1828wXPITVTv8f7oxx5W3lFFgpFAyYMmROC'
+        '4Ee9qG5T38LFe8_oAuFCEntimWxN9F3P-FJQy43TL7wG54WodgiM0EgzkeLr5K6cDnyckWjTuZbWI-4ffcTgTZsL_Kq1owa_J2ngEfxMCObnzG'
+        'y5ZLcTUomo4rZLjghVpq6KZxfS6I1Vz79ZsMVUWEdXOYePCKKsrQG20ogQEkmTf9FT_SouC6jPcHLXw"}]}'
+    ),
+    'JWT_ISSUERS': [{
+        'AUDIENCE': 'lms-key',
+        'ISSUER': 'http://localhost:18000/oauth2',
+        'SECRET_KEY': 'lms-secret',
+    }],
+})
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.


### PR DESCRIPTION
[MICROBA-521]
- Update default JWT auth settings for development in Credentials with latest from cookiecutter IDA settings


