### PR TITLE
Use class to fix faker warning

### DIFF
--- a/credentials/apps/records/management/commands/seed-records.py
+++ b/credentials/apps/records/management/commands/seed-records.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         """ Seed all catalog data """
         # Make predictable UUIDs using faker
         faker = Faker()
-        faker.seed(1234)
+        Faker.seed(1234)
 
         site = Command.get_site(site_name)
         organizations = Command.seed_organizations(site, faker)


### PR DESCRIPTION
Use class to fix faker warning reported in travis build.

https://travis-ci.org/github/edx/credentials/jobs/732347131

> Traceback (most recent call last):
>   File "./manage.py", line 15, in <module>
>     execute_from_command_line(sys.argv)
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
>     utility.execute()
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/__init__.py", line 375, in execute
>     self.fetch_command(subcommand).run_from_argv(self.argv)
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/base.py", line 323, in run_from_argv
>     self.execute(*args, **cmd_options)
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/base.py", line 364, in execute
>     output = self.handle(*args, **options)
>   File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 48, in handle
>     Command.seed_all(site_name, username)
>   File "/usr/lib/python3.8/contextlib.py", line 75, in inner
>     return func(*args, **kwds)
>   File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 62, in seed_all
>     faker.seed(1234)
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/faker/proxy.py", line 84, in __getattribute__
>     raise TypeError(msg)
> TypeError: Calling `.seed()` on instances is deprecated. Use the class method `Faker.seed()` instead.