### PR TITLE
Fix many to many warnings

### DIFF
--- a/credentials/apps/records/management/commands/seed-records.py
+++ b/credentials/apps/records/management/commands/seed-records.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
                 uuid=faker.uuid4(),
                 title="Course {}".format(course_id),
                 key="Course-{}".format(course_id))
-            course1.owners = [organization]
+            course1.owners.set([organization])
             courses.append(course1)
             Command.log_action("Course", course_id, created)
 
@@ -122,7 +122,7 @@ class Command(BaseCommand):
                 uuid=faker.uuid4(),
                 title="Course {}".format(course_id + 1),
                 key="Course-{}".format(course_id + 1))
-            course2.owners = [organization]
+            course2.owners.set([organization])
             courses.append(course2)
             Command.log_action("Course", course_id + 1, created)
 
@@ -172,8 +172,8 @@ class Command(BaseCommand):
                     'status': 'active',
                 },
             )
-            program.course_runs = course_runs
-            program.authoring_organizations = [organization]
+            program.course_runs.set(course_runs)
+            program.authoring_organizations.set([organization])
             Command.log_action("Program", program_id, created)
 
             programs.append(program)
@@ -233,7 +233,7 @@ class Command(BaseCommand):
                     'language': 'en',
                 },
             )
-            program_certificate.signatories = signatories
+            program_certificate.signatories.set(signatories)
             program_certificate.save()
 
             Command.log_action("Program certificate for", program.title, created)
@@ -255,7 +255,7 @@ class Command(BaseCommand):
                     'certificate_type': CertificateType.VERIFIED,
                 }
             )
-            course_certificate.signatories = signatories
+            course_certificate.signatories.set(signatories)
             course_certificate.save()
             Command.log_action("Course certificate for course run", course_run, created)
             course_certificates.append(course_certificate)
@@ -316,7 +316,7 @@ class Command(BaseCommand):
             name='All program pathway',
             org_name="MIT",
             uuid=faker.uuid4())
-        all_program_pathway.programs = programs
+        all_program_pathway.programs.set(programs)
         Command.log_action("Pathway with name", all_program_pathway.name, created)
 
         one_program_pathway, created = Pathway.objects.get_or_create(
@@ -324,7 +324,7 @@ class Command(BaseCommand):
             name='One program pathway',
             org_name="MIT",
             uuid=faker.uuid4())
-        one_program_pathway.programs = [programs[0]]
+        one_program_pathway.programs.set([programs[0]])
         Command.log_action("Pathway with name", one_program_pathway.name, created)
 
         return [all_program_pathway, one_program_pathway]
@@ -353,7 +353,7 @@ class Command(BaseCommand):
                 'pathway_type': PathwayType.INDUSTRY.value,
             },
         )
-        industry_pathway.programs = programs
+        industry_pathway.programs.set(programs)
         Command.log_action("Industry pathway with name", industry_pathway.name, created)
 
         return industry_pathway


### PR DESCRIPTION
Similar fix as https://github.com/edx/credentials/pull/740

Fix many to many warning reported by travis build: https://travis-ci.org/github/edx/credentials/jobs/732997936

> 2020-10-05 15:12:48,036 INFO 194 [credentials.apps.records.management.commands.seed-records] seed-records.py:54 - Organization Test-Org-2 Created
> Traceback (most recent call last):
>   File "./manage.py", line 15, in <module>
>     execute_from_command_line(sys.argv)
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
>     utility.execute()
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/__init__.py", line 375, in execute
>     self.fetch_command(subcommand).run_from_argv(self.argv)
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/base.py", line 323, in run_from_argv
>     self.execute(*args, **cmd_options)
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/base.py", line 364, in execute
>     output = self.handle(*args, **options)
>   File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 48, in handle
>     Command.seed_all(site_name, username)
>   File "/usr/lib/python3.8/contextlib.py", line 75, in inner
>     return func(*args, **kwds)
>   File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 66, in seed_all
>     courses = Command.seed_courses(site, organizations, faker)
>   File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 116, in seed_courses
>     course1.owners = [organization]
>   File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/db/models/fields/related_descriptors.py", line 536, in __set__
>     raise TypeError(
> TypeError: Direct assignment to the forward side of a many-to-many set is prohibited. Use owners.set() instead.
> The command "make exec-accept" exited with 0.
> cache.2

Once that was fixed, travis reported:

> 2020-10-05 15:59:16,882 INFO 194 [credentials.apps.records.management.commands.seed-records] seed-records.py:54 - CourseRun for Course 4 Created
Traceback (most recent call last):
  File "./manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 48, in handle
    Command.seed_all(site_name, username)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 68, in seed_all
    programs = Command.seed_programs(site, organizations, course_runs, faker)
  File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 175, in seed_programs
    program.course_runs = course_runs
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/db/models/fields/related_descriptors.py", line 536, in __set__
    raise TypeError(
TypeError: Direct assignment to the forward side of a many-to-many set is prohibited. Use course_runs.set() instead.
The command "make exec-accept" exited with 0.

And then:

> Traceback (most recent call last):
  File "./manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 48, in handle
    Command.seed_all(site_name, username)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 68, in seed_all
    programs = Command.seed_programs(site, organizations, course_runs, faker)
  File "/edx/app/credentials/credentials/credentials/apps/records/management/commands/seed-records.py", line 176, in seed_programs
    program.authoring_organizations = [organization]
  File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/db/models/fields/related_descriptors.py", line 536, in __set__
    raise TypeError(
TypeError: Direct assignment to the forward side of a many-to-many set is prohibited. Use authoring_organizations.set() instead.

Etc.