### PR TITLE
Fix upgrades by pinning library

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,3 +31,6 @@ django-storages<1.9
 
 # This package is pinned due to openedx.atlassian.net/browse/ARCHBOM-1078
 social-auth-core<3.3.0
+
+# v 2.0 is giving incompatible versions errors on upgrade
+importlib-metadata==1.7.0


### PR DESCRIPTION
importlib-metadata is breaking in `make upgrade`. Pinning the
version until the upstream fixes are released.

Note: verifed that `make upgrade` works locally, but going to let the job do the upgrade.