### PR TITLE
MICROBA-634 Add code-annotations dependency

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,6 +16,7 @@ django-debug-toolbar
 django-hijack
 django-extensions
 django-filter
+django-ratelimit
 django-rest-swagger
 django-sortedm2m
 django-statici18n
@@ -40,10 +41,10 @@ python-memcached
 pytz
 requests
 xss-utils
-django-ratelimit
 
 
 # TODO Install in configuration
 git+https://github.com/edx/credentials-themes.git@0.1.31#egg=edx_credentials_themes==0.1.31
 
+# Pin was added in BOM-1260. Ticket to unpin is BOM-1676
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,10 +9,9 @@
 # linking to it here is good.
 
 # Required to resolve requirements from base.in with inherited files
-stevedore==1.10.0
 path.py==12.0.2
 
-# Remaining version pins to maintain behavior in
+# code-annotations currently restricts to Django<2.3
 Django<2.3
 
 # Functional pin for dev.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -15,6 +15,7 @@
 -r base.txt
 
 bok-choy
+code-annotations          # provides commands used by the pii_check make target
 coverage
 ddt
 edx-lint


### PR DESCRIPTION
1. Add code-annotations dependency. 
2. Unpin stevedore (we need a later version for code-annotations to work). 
3. Update comments and alphabetize.