### PR TITLE
ARCHBOM-1569: Add a mock toggles state endpoint

### DIFF
--- a/credentials/urls.py
+++ b/credentials/urls.py
@@ -26,7 +26,7 @@ from rest_framework_swagger.views import get_swagger_view
 
 from credentials.apps.core import views as core_views
 from credentials.apps.records.views import ProgramListingView
-from credentials.views import FaviconView
+from credentials.views import FaviconView, MockToggleStateView
 
 
 admin.autodiscover()
@@ -47,6 +47,7 @@ urlpatterns = oauth2_urlpatterns + [
     url(r'^records/', include(('credentials.apps.records.urls', 'records'), namespace='records')),
     url(r'^program-listing/', ProgramListingView.as_view(), name='program_listing'),
     url(r'^favicon\.ico$', FaviconView.as_view(permanent=True)),
+    url(r'^mock-toggles$', MockToggleStateView.as_view()),
     url(r'^hijack/', include('hijack.urls', namespace='hijack')),
 ]
 

--- a/credentials/views.py
+++ b/credentials/views.py
@@ -20,8 +20,7 @@ class FaviconView(RedirectView):
         return urljoin(site_configuration.homepage_url, '/favicon.ico')
 
 
-# pragma: no cover
-class MockToggleStateView(views.APIView):
+class MockToggleStateView(views.APIView):  # pragma: no cover
     """
     A mock endpoint showing that we can require a staff JWT in this IDA,
     and allowing us to test integration of multiple IDAs into toggle state

--- a/credentials/views.py
+++ b/credentials/views.py
@@ -1,6 +1,11 @@
 from urllib.parse import urljoin
 
 from django.views.generic.base import RedirectView
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.permissions import IsStaff
+from rest_framework.authentication import SessionAuthentication
+from rest_framework import permissions, views
+from rest_framework.response import Response
 
 
 class FaviconView(RedirectView):
@@ -12,3 +17,38 @@ class FaviconView(RedirectView):
         if not site_configuration.homepage_url:
             return None
         return urljoin(site_configuration.homepage_url, '/favicon.ico')
+
+
+class MockToggleStateView(views.APIView):
+    """
+    A mock endpoint showing that we can require a staff JWT in this IDA,
+    and allowing us to test integration of multiple IDAs into toggle state
+    reports (ARCHBOM-1569). This can go away once edx-toggles is ready and
+    integrated.
+    """
+    authentication_classes = (JwtAuthentication, SessionAuthentication,)
+    permission_classes = (permissions.IsAuthenticated, IsStaff,)
+
+    def get(self, request):
+        return Response({
+            "waffle_flags": [
+                {
+                    "name": "mock.flag",
+                    "class": "WaffleFlag",
+                    "module": "mock.core.djangoapps.fake",
+                    "code_owner": "platform-arch",
+                    "computed_status": "off"
+                }
+            ],
+            "waffle_switches": [],
+            "django_settings": [
+                {
+                    "name": "MOCK_DEBUG",
+                    "is_active": False
+                },
+                {
+                    "name": "OTHER_MOCK['stuff']",
+                    "is_active": True
+                }
+            ]
+        })

--- a/credentials/views.py
+++ b/credentials/views.py
@@ -20,6 +20,7 @@ class FaviconView(RedirectView):
         return urljoin(site_configuration.homepage_url, '/favicon.ico')
 
 
+# pragma: no cover
 class MockToggleStateView(views.APIView):
     """
     A mock endpoint showing that we can require a staff JWT in this IDA,

--- a/credentials/views.py
+++ b/credentials/views.py
@@ -1,10 +1,11 @@
 from urllib.parse import urljoin
 
 from django.views.generic.base import RedirectView
+
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.permissions import IsStaff
-from rest_framework.authentication import SessionAuthentication
 from rest_framework import permissions, views
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
 


### PR DESCRIPTION
As part of Architecture's observability work, we're adding endpoints to IDAs that can dump the current state of various toggles.  This is a mock endpoint that accomplishes two things: 1) confirm that we can require a staff JWT in another IDA than edxapp, and 2) allow us to test integration of multiple IDAs into toggle state reports before the edx-toggles djangoapp is ready for use.

This can go away once edx-toggles is ready and integrated.

You can test locally in devstack: http://localhost:18150/mock-toggles