### PR TITLE
EDUCATOR-5400: gracefully handle the facebook button not existing

### DIFF
--- a/credentials/static/js/sharing.js
+++ b/credentials/static/js/sharing.js
@@ -18,7 +18,7 @@ function initializeFacebook() {
   FB.AppEvents.logPageView();
 
   // Activate the sharing button
-  if(shareButton !== null){
+  if (shareButton !== null) {
     shareButton.removeAttribute('disabled');
     shareButton.addEventListener('click', addFacebookClickHandler);
   }

--- a/credentials/static/js/sharing.js
+++ b/credentials/static/js/sharing.js
@@ -18,8 +18,10 @@ function initializeFacebook() {
   FB.AppEvents.logPageView();
 
   // Activate the sharing button
-  shareButton.removeAttribute('disabled');
-  shareButton.addEventListener('click', addFacebookClickHandler);
+  if(shareButton !== null){
+    shareButton.removeAttribute('disabled');
+    shareButton.addEventListener('click', addFacebookClickHandler);
+  }
 }
 
 window.fbAsyncInit = initializeFacebook;

--- a/credentials/static/js/test/specs/sharing_spec.js
+++ b/credentials/static/js/test/specs/sharing_spec.js
@@ -48,8 +48,8 @@ describe('sharing module', () => {
     });
 
     it('should handle the share button not existing', () => {
-        facebookShareButton.remove()
-        initializeFacebook();
+      facebookShareButton.remove()
+      initializeFacebook(); // eslint-disable-line no-undef
     });
   });
 });

--- a/credentials/static/js/test/specs/sharing_spec.js
+++ b/credentials/static/js/test/specs/sharing_spec.js
@@ -48,7 +48,7 @@ describe('sharing module', () => {
     });
 
     it('should handle the share button not existing', () => {
-      facebookShareButton.remove()
+      facebookShareButton.remove();
       initializeFacebook(); // eslint-disable-line no-undef
     });
   });

--- a/credentials/static/js/test/specs/sharing_spec.js
+++ b/credentials/static/js/test/specs/sharing_spec.js
@@ -46,5 +46,10 @@ describe('sharing module', () => {
 
       expect(FB.ui).toHaveBeenCalledWith(expected);
     });
+
+    it('should handle the share button not existing', () => {
+        facebookShareButton.remove()
+        initializeFacebook();
+    });
   });
 });


### PR DESCRIPTION
[EDUCATOR-5400](https://openedx.atlassian.net/browse/EDUCATOR-5400)

We've seen several newrelic alerts for the past few days that are caused by this error with facebook integration.

Simple change to prevent these errors from popping up when the facebook badge isn't present (it's currently never present)