### PR TITLE
MICROBA-639 Remove file path with no entries

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,6 @@ module.exports = function (config) {
     files: [
       'credentials/static/js/test/spec-runner.js',
       'credentials/static/js/**/*.js',
-      'credentials/static/components/**/*.js',
       {pattern: 'credentials/static/js/test/fixtures/**/*.html', included: false, served: true, watched: true},
 
     ],


### PR DESCRIPTION
Fixes warning in django builds: _WARN [watcher]: Pattern "/edx/app/credentials/credentials/credentials/static/components/**/*.js" does not match any file_