### PR TITLE
MICROBA-639 Add key

### DIFF
--- a/credentials/static/components/SendLearnerRecordModal.jsx
+++ b/credentials/static/components/SendLearnerRecordModal.jsx
@@ -143,6 +143,7 @@ class SendLearnerRecordModal extends React.Component {
         buttons={[
           <Button.Deprecated
             label={gettext('Send')}
+            key="send"
             buttonType="primary"
             onClick={this.callSendHandler}
             disabled={this.state.numCheckedOrganizations <= 0}

--- a/credentials/static/components/specs/SendLearnerRecordModal.test.jsx
+++ b/credentials/static/components/specs/SendLearnerRecordModal.test.jsx
@@ -31,13 +31,16 @@ const defaultProps = {
   creditPathwaysList: [
     {
       name: 'testX',
+      id: 1,
       status: '',
     },
     {
       name: 'MITx',
+      id: 2,
       status: 'sent',
     },
     { name: 'HarvardX',
+      id: 3,
       status: '',
     },
   ],


### PR DESCRIPTION
Fixes build warnings

    console.error
      Warning: Each child in a list should have a unique "key" prop.
      
      Check the render method of `Modal`. It was passed a child from SendLearnerRecordModal. See https://fb.me/react-warning-keys for more information.
          in withDeprecatedProps(Button) (created by SendLearnerRecordModal)
          in Modal (created by SendLearnerRecordModal)
          in SendLearnerRecordModal (created by ProgramRecord)
          in main (created by ProgramRecord)
          in ProgramRecord (created by WrapperComponent)
          in WrapperComponent

and

    console.error
      Warning: Each child in a list should have a unique "key" prop.
      
      Check the render method of `SendLearnerRecordModal`. See https://fb.me/react-warning-keys for more information.
          in withDeprecatedProps(asInput) (created by SendLearnerRecordModal)
          in SendLearnerRecordModal (created by WrapperComponent)
          in WrapperComponent
