### PR TITLE
Switch program_details to use in service catalog [MICROBA-726]

### DIFF
--- a/credentials/apps/catalog/api.py
+++ b/credentials/apps/catalog/api.py
@@ -1,0 +1,51 @@
+from .data import OrganizationDetails, ProgramDetails
+from .models import Program as _Program
+
+
+def get_program_details_by_uuid(uuid, site):
+    try:
+        program = _Program.objects.get(uuid=uuid, site=site)
+    except _Program.DoesNotExist:
+        return None
+
+    return _convert_program_to_program_details(program)
+
+
+def _convert_program_to_program_details(
+    program,
+):
+    """
+    Converts a Program (model instance) into a ProgramDetails dataclass.
+
+    Eventually we should move towards a standard portable dataclass that we can
+    pass between apps, but this will use the legacy dataclass that the rest
+    of the code uses until that time.
+
+    `credential_title` is a empty field which will be overwritten by the
+    consuming app that has an override for it. Eventually it should be removed
+    from this data.
+    """
+    program_authoring_organizations = program.authoring_organizations.all()
+    program_course_runs = program.course_runs.all()
+
+    organizations = [
+        OrganizationDetails(
+            uuid=organization.uuid,
+            key=organization.key,
+            name=organization.name,
+            display_name=organization.key,
+            certificate_logo_image_url=organization.certificate_logo_image_url
+        )
+        for organization
+        in program_authoring_organizations
+    ]
+
+    return ProgramDetails(
+        uuid=program.uuid,
+        title=program.title,
+        type=program.type_slug,
+        credential_title=None,
+        course_count=len(program_course_runs),
+        organizations=organizations,
+        hours_of_effort=program.total_hours_of_effort
+    )

--- a/credentials/apps/catalog/data.py
+++ b/credentials/apps/catalog/data.py
@@ -1,0 +1,34 @@
+"""
+Public data structures for this app.
+
+This should only ever be consumed and should never import anything other than
+stdlib modules, so that it may be consumed everywhere.
+"""
+
+from dataclasses import dataclass
+
+
+# Currently using a dataclass version of the legacy namedtuples so the consuming
+# app can mutate them for their needs. Future version should use frozen
+# dataclasses and consuming app can create their own internal structures using
+# the values from the frozen data rather than dataclass with too many
+# requirements.
+@dataclass
+class OrganizationDetails:
+    uuid: str
+    key: str
+    name: str
+    display_name: str
+    certificate_logo_image_url: str
+
+
+# See comment above OrganizationDetails
+@dataclass
+class ProgramDetails:
+    uuid: str
+    title: str
+    type: str
+    credential_title: str
+    course_count: int
+    organizations: list
+    hours_of_effort: int

--- a/credentials/apps/catalog/tests/test_api.py
+++ b/credentials/apps/catalog/tests/test_api.py
@@ -1,0 +1,26 @@
+import uuid
+
+from django.test import TestCase
+
+from credentials.apps.catalog.api import get_program_details_by_uuid
+from credentials.apps.catalog.data import ProgramDetails
+from credentials.apps.catalog.tests.factories import ProgramFactory, SiteFactory
+
+
+class APITests(TestCase):
+    """ Tests internal API calls """
+    def setUp(self):
+        super().setUp()
+        self.site = SiteFactory()
+
+    def test_get_program_details(self):
+        program_uuid = uuid.uuid4()
+        unused_program_uuid = uuid.uuid4()
+        program = ProgramFactory.create(uuid=program_uuid, site=self.site)
+
+        details = get_program_details_by_uuid(uuid=program_uuid, site=program.site)
+        self.assertIsNotNone(details)
+        self.assertIsInstance(details, ProgramDetails)
+
+        details = get_program_details_by_uuid(uuid=unused_program_uuid, site=program.site)
+        self.assertIsNone(details)

--- a/credentials/apps/credentials/exceptions.py
+++ b/credentials/apps/credentials/exceptions.py
@@ -2,3 +2,9 @@ class MissingCertificateLogoError(Exception):
     """ Raised when a Program fetched as part of a program certificate configuration
      has an organization without a defined certificate logo image url
     """
+
+
+class NoMatchingProgramException(Exception):
+    """
+    Raised when a ProgramCertificate doesn't have a matching program linked to it.
+    """

--- a/credentials/apps/credentials/tests/test_models.py
+++ b/credentials/apps/credentials/tests/test_models.py
@@ -159,7 +159,8 @@ class ProgramCertificateTests(SiteMixin, TestCase):
         # replace good UUID with new one
         program_certificate.program_uuid = uuid.uuid4()
         with self.assertRaises(NoMatchingProgramException):
-            program_certificate.program_details
+            # attempt to access the program_details property
+            program_certificate.program_details   # pylint: disable=pointless-statement
 
     def test_get_program_api_data(self):
         """ Verify the method returns data from the Catalog API. """

--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -11,9 +11,10 @@ from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
 
+from credentials.apps.catalog.data import OrganizationDetails, ProgramDetails
 from credentials.apps.core.views import ThemeViewMixin
 from credentials.apps.credentials.exceptions import MissingCertificateLogoError
-from credentials.apps.credentials.models import OrganizationDetails, ProgramCertificate, ProgramDetails, UserCredential
+from credentials.apps.credentials.models import ProgramCertificate, UserCredential
 from credentials.apps.credentials.utils import get_credential_visible_date, to_language
 
 
@@ -141,7 +142,6 @@ class ExampleCredential(SocialMediaMixin, ThemeViewMixin, TemplateView):
         program_details = ProgramDetails(
             uuid=uuid.uuid4(),
             title='Completely Example Program',
-            subtitle='Example Subtitle',
             type=program_type,
             credential_title=None,
             course_count=3,


### PR DESCRIPTION
Instead of relying on cached calls to the discovery API, this uses the
in-service catalog to support program_details which certificates use.

Also removed subtitle since no code is actively using it.