### PR TITLE
Don't throttle staff accounts

### DIFF
--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -54,7 +54,7 @@ class CredentialRateThrottle(ScopedRateThrottle):
     def allow_request(self, request, view):
         user = request.user
         if user.is_authenticated and (user.is_staff or user.is_superuser):
-            view.throttle_scope = 'staff_override'
+            view.throttle_scope = None
 
         return super().allow_request(request, view)
 


### PR DESCRIPTION
My decision for disabling it entirely for staff is that the 1500 req/min is useless. If we ever got to 1500 req/min, the caching of the ratelimiting would actually kill us before the users requests would have a chance to get there.