### PR TITLE
MICROBA-639 Fix warnings

### DIFF
--- a/credentials/apps/catalog/tests/test_utils.py
+++ b/credentials/apps/catalog/tests/test_utils.py
@@ -15,6 +15,7 @@ from credentials.apps.catalog.utils import (
     parse_program,
 )
 from credentials.apps.core.tests.factories import SiteFactory
+from credentials.settings.base import TIME_ZONE_CLASS
 from credentials.shared.constants import PathwayType
 
 
@@ -34,7 +35,8 @@ class ParseTests(TestCase):
                        'start_date': '2018-01-01T00:00:00Z', 'end_date': '2018-06-01T00:00:00Z'}
     COURSERUN1_VALUES = {'uuid': '33f0dded-fee9-4dec-a333-b9d8c2c82bd3', 'key': 'runkey',
                          'title_override': 'Course Run Title',
-                         'start_date': datetime(2018, 1, 1), 'end_date': datetime(2018, 6, 1)}
+                         'start_date': datetime(2018, 1, 1, tzinfo=TIME_ZONE_CLASS),
+                         'end_date': datetime(2018, 6, 1, tzinfo=TIME_ZONE_CLASS)}
 
     COURSE1_DATA = {'uuid': '33f0dded-fee9-4dec-a333-b9d8c2c82bd4', 'key': 'coursekey', 'title': 'Course Title',
                     'owners': [ORG1_DATA], 'course_runs': [COURSERUN1_DATA]}

--- a/credentials/apps/records/management/commands/seed-records.py
+++ b/credentials/apps/records/management/commands/seed-records.py
@@ -13,6 +13,7 @@ from credentials.apps.credentials.constants import CertificateType
 from credentials.apps.credentials.models import CourseCertificate, ProgramCertificate, Signatory, UserCredential
 from credentials.apps.records.constants import UserCreditPathwayStatus
 from credentials.apps.records.models import ProgramCertRecord, UserCreditPathway, UserGrade
+from credentials.settings.base import TIME_ZONE_CLASS
 from credentials.shared.constants import PathwayType
 
 
@@ -143,8 +144,8 @@ class Command(BaseCommand):
             course_run, created = CourseRun.objects.get_or_create(
                 course=course,
                 uuid=faker.uuid4(),
-                start_date=datetime(2018, 1, 1),
-                end_date=datetime(2018, 6, 1),
+                start_date=datetime(2018, 1, 1, tzinfo=TIME_ZONE_CLASS),
+                end_date=datetime(2018, 6, 1, tzinfo=TIME_ZONE_CLASS),
                 key=key,
             )
 

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -1,9 +1,11 @@
 import os
+from datetime import timezone
 from os.path import abspath, dirname, join
 
 from django.conf.global_settings import LANGUAGES_BIDI
 
 from credentials.settings.utils import get_logger_config
+
 
 # PATH vars
 
@@ -205,6 +207,7 @@ LANGUAGE_CODE = 'en'
 LANGUAGES_BIDI = LANGUAGES_BIDI + ['rtl']
 
 TIME_ZONE = 'UTC'
+TIME_ZONE_CLASS = timezone.utc
 
 USE_I18N = True
 

--- a/jest-config.json
+++ b/jest-config.json
@@ -4,7 +4,7 @@
   ],
   "transform": {
     "^.+\\.jsx?$": "babel-jest",
-    "^.+\\.svg$": "<rootDir>/svgTransform.js" 
+    "^.+\\.svg$": "<rootDir>/svgTransform.js"
   },
   "setupFiles": [
     "./jest_setup/shim.js",
@@ -23,5 +23,6 @@
   ],
   "transformIgnorePatterns": [
     "/node_modules/(?!(@edx/paragon)/).*/"
-  ]
+  ],
+  "watchman": false
 }


### PR DESCRIPTION
Fixes:

> 
> /edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/db/models/fields/__init__.py:1424: RuntimeWarning: DateTimeField CourseRun.end_date received a naive datetime (2018-06-01 00:00:00) while time zone support is active.
>   warnings.warn("DateTimeField %s received a naive datetime (%s)"

and

> edx-credentials@ test-react /edx/app/credentials/credentials
> > jest --no-cache --coverage  --config ./jest-config.json
> 
> jest-haste-map: Watchman crawl failed. Retrying once with node crawler.
>   Usually this happens when watchman isn't running. Create an empty `.watchmanconfig` file in your project's root folder or initialize a git or hg repository in your project.
>   Error: Watchman error: A non-recoverable condition has triggered.  Watchman needs your help!
> The triggering condition was at timestamp=1608310865: inotify-add-watch(/edx/app/credentials/credentials/.tox/django31/lib/python3.8/site-packages/openid/yadis/__pycache__) -> The user limit on the total number of inotify watches was reached; increase the fs.inotify.max_user_watches sysctl
> All requests will continue to fail with this message until you resolve
> the underlying problem.  You will find more information on fixing this at
> https://facebook.github.io/watchman/docs/troubleshooting.html#poison-inotify-add-watch. Make sure watchman is running for this project. See https://facebook.github.io/watchman/docs/troubleshooting.
> 