### PR TITLE
MICROBA-639 Replace ugettext_lazy with gettext_lazy

### DIFF
--- a/credentials/apps/core/admin.py
+++ b/credentials/apps/core/admin.py
@@ -2,7 +2,7 @@
 
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from credentials.apps.core.forms import SiteConfigurationAdminForm
 from credentials.apps.core.models import SiteConfiguration, User

--- a/credentials/apps/core/models.py
+++ b/credentials/apps/core/models.py
@@ -9,7 +9,7 @@ from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from edx_rest_api_client.client import EdxRestApiClient
 
 

--- a/credentials/apps/credentials/forms.py
+++ b/credentials/apps/credentials/forms.py
@@ -5,7 +5,7 @@ from operator import itemgetter
 
 from django import forms
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from credentials.apps.credentials.models import ProgramCertificate, Signatory
 

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -13,7 +13,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey

--- a/credentials/apps/records/models.py
+++ b/credentials/apps/records/models.py
@@ -5,7 +5,7 @@ import uuid
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
 
 from credentials.apps.catalog.models import CourseRun, Pathway, Program

--- a/credentials/urls.py
+++ b/credentials/urls.py
@@ -21,7 +21,7 @@ from django.conf.urls import include
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import re_path
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.defaults import page_not_found
 from rest_framework_swagger.views import get_swagger_view
 


### PR DESCRIPTION
Fixes

> credentials/apps/core/models.py:24
>   /edx/app/credentials/credentials/credentials/apps/core/models.py:24: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
>     verbose_name=_('Platform Name'),
> 