### PR TITLE
MICROBA-639 Replace ugettext with gettext

### DIFF
--- a/credentials/apps/core/forms.py
+++ b/credentials/apps/core/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from credentials.apps.core.models import SiteConfiguration
 

--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import slugify
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
 from credentials.apps.catalog.data import OrganizationDetails, ProgramDetails

--- a/credentials/apps/edx_django_extensions/views.py
+++ b/credentials/apps/edx_django_extensions/views.py
@@ -3,7 +3,7 @@ import logging
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.core.cache import cache
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
 

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -15,7 +15,7 @@ from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic import TemplateView, View
 from edx_ace import Recipient, ace
 from ratelimit.decorators import ratelimit


### PR DESCRIPTION
Fixes

> credentials/apps/core/tests/test_forms.py::SiteConfigurationAdminFormTests::test_clean_with_invalid_facebook_config_1_
> credentials/apps/core/tests/test_forms.py::SiteConfigurationAdminFormTests::test_clean_with_invalid_facebook_config_2_None
>   /edx/app/credentials/credentials/credentials/apps/core/forms.py:12: RemovedInDjango40Warning: django.utils.translation.ugettext() is deprecated in favor of django.utils.translation.gettext().
>     message = _('A Facebook app ID is required to enable Facebook sharing.')
> 