### PR TITLE
BOM-2183 : Unpin social-auth-core

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -11,8 +11,8 @@ attrs==20.3.0             # via -r requirements/dev.txt, -r requirements/product
 bcrypt==3.2.0             # via -r requirements/dev.txt, paramiko
 bleach==3.2.1             # via -r requirements/dev.txt, -r requirements/production.txt
 bok-choy==1.1.1           # via -r requirements/dev.txt
-boto3==1.16.38            # via -r requirements/production.txt, django-ses
-botocore==1.19.38         # via -r requirements/production.txt, boto3, s3transfer
+boto3==1.16.50            # via -r requirements/production.txt, django-ses
+botocore==1.19.50         # via -r requirements/production.txt, boto3, s3transfer
 cached-property==1.5.2    # via -r requirements/dev.txt, docker-compose
 certifi==2020.12.5        # via -r requirements/dev.txt, -r requirements/production.txt, requests
 cffi==1.14.4              # via -r requirements/dev.txt, -r requirements/production.txt, bcrypt, cryptography, pynacl
@@ -22,7 +22,7 @@ click==7.1.2              # via -r requirements/dev.txt, click-log, code-annotat
 code-annotations==0.10.2  # via -r requirements/dev.txt
 coreapi==2.3.3            # via -r requirements/dev.txt, -r requirements/production.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/dev.txt, -r requirements/production.txt, coreapi
-coverage==5.3             # via -r requirements/dev.txt
+coverage==5.3.1           # via -r requirements/dev.txt
 cryptography==3.3.1       # via -r requirements/dev.txt, -r requirements/production.txt, paramiko, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/dev.txt
 defusedxml==0.6.0         # via -r requirements/dev.txt, -r requirements/production.txt, python3-openid, social-auth-core
@@ -41,13 +41,13 @@ django-ses==1.0.3         # via -r requirements/production.txt
 django-simple-history==2.12.0  # via -r requirements/dev.txt, -r requirements/production.txt
 django-sortedm2m==3.0.2   # via -r requirements/dev.txt, -r requirements/production.txt
 django-statici18n==2.0.1  # via -r requirements/dev.txt, -r requirements/production.txt
-django-storages==1.11     # via -r requirements/dev.txt, -r requirements/production.txt
+django-storages==1.11.1   # via -r requirements/dev.txt, -r requirements/production.txt
 django-waffle==2.0.0      # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/dev.txt, -r requirements/production.txt
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, code-annotations, django-appconf, django-crum, django-debug-toolbar, django-filter, django-ses, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, xss-utils
 djangorestframework==3.12.2  # via -r requirements/dev.txt, -r requirements/production.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 docker-compose==1.27.4    # via -c requirements/constraints.txt, -r requirements/dev.txt
-docker[ssh]==4.4.0        # via -r requirements/dev.txt, docker-compose
+docker[ssh]==4.4.1        # via -r requirements/dev.txt, docker-compose
 dockerpty==0.4.1          # via -r requirements/dev.txt, docker-compose
 docopt==0.6.2             # via -r requirements/dev.txt, docker-compose
 drf-jwt==1.17.3           # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions
@@ -58,20 +58,20 @@ edx-django-sites-extensions==2.5.1  # via -r requirements/dev.txt, -r requiremen
 edx-django-utils==3.13.0  # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/dev.txt, -r requirements/production.txt
 edx-i18n-tools==0.5.3     # via -r requirements/dev.txt, -r requirements/production.txt, edx-credentials-themes
-edx-lint==1.5.2           # via -r requirements/dev.txt
+edx-lint==1.5.2           # via -c requirements/constraints.txt, -r requirements/dev.txt
 edx-opaque-keys==2.1.1    # via -r requirements/dev.txt, -r requirements/production.txt, edx-drf-extensions
 edx-rest-api-client==5.2.2  # via -r requirements/dev.txt, -r requirements/production.txt
 git+https://github.com/edx/credentials-themes.git@0.1.46#egg=edx_credentials_themes==0.1.46  # via -r requirements/dev.txt, -r requirements/production.txt
-factory-boy==3.1.0        # via -r requirements/dev.txt
-faker==5.0.2              # via -r requirements/dev.txt, factory-boy
+factory-boy==3.2.0        # via -r requirements/dev.txt
+faker==5.3.0              # via -r requirements/dev.txt, factory-boy
 filelock==3.0.12          # via -r requirements/dev.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/dev.txt, -r requirements/production.txt, django-ses, pyjwkest
-gevent==20.9.0            # via -r requirements/production.txt
+gevent==20.12.1           # via -r requirements/production.txt
 gitdb==4.0.5              # via -r requirements/dev.txt, -r requirements/production.txt, gitpython
-gitpython==3.1.11         # via -r requirements/dev.txt, -r requirements/production.txt, transifex-client
+gitpython==3.1.12         # via -r requirements/dev.txt, -r requirements/production.txt, transifex-client
 greenlet==0.4.17          # via -r requirements/production.txt, gevent
 gunicorn==20.0.4          # via -r requirements/production.txt
-httpretty==1.0.3          # via -r requirements/dev.txt
+httpretty==1.0.5          # via -r requirements/dev.txt
 idna==2.10                # via -r requirements/dev.txt, -r requirements/production.txt, requests
 iniconfig==1.1.1          # via -r requirements/dev.txt, pytest
 isort==4.3.21             # via -r requirements/dev.txt, pylint
@@ -84,8 +84,8 @@ lazy==1.4                 # via -r requirements/dev.txt, bok-choy
 markdown==3.3.3           # via -r requirements/dev.txt, -r requirements/production.txt
 markupsafe==1.1.1         # via -r requirements/dev.txt, -r requirements/production.txt, jinja2
 mccabe==0.6.1             # via -r requirements/dev.txt, pylint
-mysqlclient==2.0.2        # via -r requirements/dev.txt, -r requirements/production.txt
-newrelic==5.22.1.152      # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/dev.txt, -r requirements/production.txt
+newrelic==5.24.0.153      # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
 nodeenv==1.5.0            # via -r requirements/production.txt
 oauthlib==3.1.0           # via -r requirements/dev.txt, -r requirements/production.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/dev.txt, -r requirements/production.txt, django-rest-swagger
@@ -94,10 +94,10 @@ paramiko==2.7.2           # via -r requirements/dev.txt, docker
 path.py==12.5.0           # via -r requirements/dev.txt, -r requirements/production.txt, edx-i18n-tools
 path==15.0.1              # via -r requirements/dev.txt, -r requirements/production.txt, path.py
 pbr==5.5.1                # via -r requirements/dev.txt, -r requirements/production.txt, stevedore
-pillow==8.0.1             # via -r requirements/dev.txt, -r requirements/production.txt
+pillow==8.1.0             # via -r requirements/dev.txt, -r requirements/production.txt
 pluggy==0.13.1            # via -r requirements/dev.txt, pytest, tox
 polib==1.1.0              # via -r requirements/dev.txt, -r requirements/production.txt, edx-i18n-tools
-psutil==5.7.3             # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/dev.txt, -r requirements/production.txt, edx-django-utils
 py==1.10.0                # via -r requirements/dev.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/dev.txt
 pycparser==2.20           # via -r requirements/dev.txt, -r requirements/production.txt, cffi
@@ -108,7 +108,7 @@ pyjwt[crypto]==1.7.1      # via -r requirements/dev.txt, -r requirements/product
 pylint-celery==0.3        # via -r requirements/dev.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/dev.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/dev.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/dev.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -c requirements/constraints.txt, -r requirements/dev.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/dev.txt, -r requirements/production.txt, edx-opaque-keys
 pynacl==1.4.0             # via -r requirements/dev.txt, paramiko
 pyparsing==2.4.7          # via -r requirements/dev.txt, -r requirements/production.txt, packaging
@@ -120,7 +120,7 @@ python-dotenv==0.15.0     # via -r requirements/dev.txt, docker-compose
 python-memcached==1.59    # via -r requirements/dev.txt, -r requirements/production.txt
 python-slugify==4.0.1     # via -r requirements/dev.txt, -r requirements/production.txt, code-annotations, transifex-client
 python3-openid==3.2.0     # via -r requirements/dev.txt, -r requirements/production.txt, social-auth-core
-pytz==2020.4              # via -r requirements/dev.txt, -r requirements/production.txt, django, django-ses
+pytz==2020.5              # via -r requirements/dev.txt, -r requirements/production.txt, django, django-ses
 pywatchman==1.4.1 ; "linux" in sys_platform  # via -r requirements/dev.txt
 pyyaml==5.3.1             # via -r requirements/dev.txt, -r requirements/production.txt, code-annotations, docker-compose, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/dev.txt, -r requirements/production.txt, social-auth-core
@@ -135,7 +135,7 @@ simplejson==3.17.2        # via -r requirements/dev.txt, -r requirements/product
 six==1.15.0               # via -r requirements/dev.txt, -r requirements/production.txt, analytics-python, astroid, bcrypt, bleach, bok-choy, cryptography, django-compat, django-simple-history, docker, dockerpty, edx-ace, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, jsonschema, pyjwkest, pynacl, python-dateutil, python-memcached, responses, social-auth-app-django, social-auth-core, tox, transifex-client, virtualenv, websocket-client
 slumber==0.7.1            # via -r requirements/dev.txt, -r requirements/production.txt, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/dev.txt, -r requirements/production.txt, gitdb
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/dev.txt, -r requirements/production.txt, edx-auth-backends
+social-auth-app-django==4.0.0  # via -r requirements/dev.txt, -r requirements/production.txt, edx-auth-backends
 social-auth-core==3.3.3   # via -r requirements/dev.txt, -r requirements/production.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/dev.txt, -r requirements/production.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/dev.txt, -r requirements/production.txt, code-annotations, edx-ace, edx-django-utils, edx-opaque-keys

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -23,7 +23,7 @@ code-annotations==0.10.2  # via -r requirements/dev.txt
 coreapi==2.3.3            # via -r requirements/dev.txt, -r requirements/production.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/dev.txt, -r requirements/production.txt, coreapi
 coverage==5.3             # via -r requirements/dev.txt
-cryptography==3.3.1       # via -r requirements/dev.txt, -r requirements/production.txt, paramiko, pyjwt
+cryptography==3.3.1       # via -r requirements/dev.txt, -r requirements/production.txt, paramiko, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/dev.txt
 defusedxml==0.6.0         # via -r requirements/dev.txt, -r requirements/production.txt, python3-openid, social-auth-core
 distlib==0.3.1            # via -r requirements/dev.txt, virtualenv
@@ -136,7 +136,7 @@ six==1.15.0               # via -r requirements/dev.txt, -r requirements/product
 slumber==0.7.1            # via -r requirements/dev.txt, -r requirements/production.txt, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/dev.txt, -r requirements/production.txt, gitdb
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/dev.txt, -r requirements/production.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/dev.txt, -r requirements/production.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -r requirements/dev.txt, -r requirements/production.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/dev.txt, -r requirements/production.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/dev.txt, -r requirements/production.txt, code-annotations, edx-ace, edx-django-utils, edx-opaque-keys
 testfixtures==6.17.0      # via -r requirements/dev.txt

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -42,11 +42,9 @@ pygments
 python-memcached
 pytz
 requests
+social-auth-app-django
 xss-utils
 
 
 # TODO Install in configuration
 git+https://github.com/edx/credentials-themes.git@0.1.46#egg=edx_credentials_themes==0.1.46
-
-# Pin was added in BOM-1260; ticket to unpin is BOM-1676
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.12.0  # via -r requirements/base.in
 django-sortedm2m==3.0.2   # via -r requirements/base.in
 django-statici18n==2.0.1  # via -r requirements/base.in
-django-storages==1.11     # via -r requirements/base.in
+django-storages==1.11.1   # via -r requirements/base.in
 django-waffle==2.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/base.in
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-appconf, django-crum, django-debug-toolbar, django-filter, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, xss-utils
@@ -44,23 +44,23 @@ edx-rest-api-client==5.2.2  # via -r requirements/base.in
 git+https://github.com/edx/credentials-themes.git@0.1.46#egg=edx_credentials_themes==0.1.46  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 gitdb==4.0.5              # via gitpython
-gitpython==3.1.11         # via transifex-client
+gitpython==3.1.12         # via transifex-client
 idna==2.10                # via requests
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 markdown==3.3.3           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
-mysqlclient==2.0.2        # via -r requirements/base.in
-newrelic==5.22.1.152      # via -r requirements/base.in, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.in
+newrelic==5.24.0.153      # via -r requirements/base.in, edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 packaging==20.8           # via bleach
 path.py==12.5.0           # via edx-i18n-tools
 path==15.0.1              # via path.py
 pbr==5.5.1                # via stevedore
-pillow==8.0.1             # via -r requirements/base.in
+pillow==8.1.0             # via -r requirements/base.in
 polib==1.1.0              # via edx-i18n-tools
-psutil==5.7.3             # via edx-django-utils
+psutil==5.8.0             # via edx-django-utils
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.9      # via pyjwkest
 pygments==2.7.3           # via -r requirements/base.in
@@ -72,7 +72,7 @@ python-dateutil==2.8.1    # via analytics-python, edx-ace, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/base.in
 python-slugify==4.0.1     # via transifex-client
 python3-openid==3.2.0     # via social-auth-core
-pytz==2020.4              # via -r requirements/base.in, django
+pytz==2020.5              # via -r requirements/base.in, django
 pyyaml==5.3.1             # via edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via -c requirements/constraints.txt, -r requirements/base.in, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, sailthru-client, slumber, social-auth-core, transifex-client
@@ -83,7 +83,7 @@ simplejson==3.17.2        # via django-rest-swagger, sailthru-client
 six==1.15.0               # via analytics-python, bleach, cryptography, django-compat, django-simple-history, edx-ace, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, transifex-client
 slumber==0.7.1            # via edx-rest-api-client
 smmap==3.0.4              # via gitdb
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
+social-auth-app-django==4.0.0  # via -r requirements/base.in, edx-auth-backends
 social-auth-core==3.3.3   # via edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via django, django-debug-toolbar
 stevedore==3.3.0          # via edx-ace, edx-django-utils, edx-opaque-keys

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via -r requirements/base.in, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==3.3.1       # via pyjwt
+cryptography==3.3.1       # via pyjwt, social-auth-core
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-appconf==1.0.4     # via django-statici18n
 django-compat==1.0.15     # via django-hijack
@@ -84,7 +84,7 @@ six==1.15.0               # via analytics-python, bleach, cryptography, django-c
 slumber==0.7.1            # via edx-rest-api-client
 smmap==3.0.4              # via gitdb
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via django, django-debug-toolbar
 stevedore==3.3.0          # via edx-ace, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via python-slugify

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,3 +20,7 @@ requests<2.25.0
 # This upgrade causes a failure in tests currently. We need to constrain it until we
 # can determine the cause of the failure. https://openedx.atlassian.net/browse/MICROBA-794
 virtualenv<20.2.2
+
+# A lot of quality failures coming on newer versions, opened BOM-2195 ticket for fixing those.
+edx-lint==1.5.2
+pylint==2.4.4

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,9 +14,6 @@ Django<2.3
 # Functional pin for dev.in
 docker-compose >= 1.5.1
 
-# This package is pinned due to openedx.atlassian.net/browse/ARCHBOM-1078
-social-auth-core<3.3.0
-
 # Later versions of requests have a version of urllib3 that conflicts with botocore. See MICROBA-727
 requests<2.25.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,7 +20,7 @@ click==7.1.2              # via -r requirements/test.txt, click-log, code-annota
 code-annotations==0.10.2  # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.3             # via -r requirements/test.txt
+coverage==5.3.1           # via -r requirements/test.txt
 cryptography==3.3.1       # via -r requirements/test.txt, paramiko, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
@@ -38,13 +38,13 @@ django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.12.0  # via -r requirements/test.txt
 django-sortedm2m==3.0.2   # via -r requirements/test.txt
 django-statici18n==2.0.1  # via -r requirements/test.txt
-django-storages==1.11     # via -r requirements/test.txt
+django-storages==1.11.1   # via -r requirements/test.txt
 django-waffle==2.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/test.txt
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-appconf, django-crum, django-debug-toolbar, django-filter, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, xss-utils
 djangorestframework==3.12.2  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
 docker-compose==1.27.4    # via -c requirements/constraints.txt, -r requirements/dev.in
-docker[ssh]==4.4.0        # via docker-compose
+docker[ssh]==4.4.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 drf-jwt==1.17.3           # via -r requirements/test.txt, edx-drf-extensions
@@ -55,17 +55,17 @@ edx-django-sites-extensions==2.5.1  # via -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in, -r requirements/test.txt, edx-credentials-themes
-edx-lint==1.5.2           # via -r requirements/test.txt
+edx-lint==1.5.2           # via -c requirements/constraints.txt, -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rest-api-client==5.2.2  # via -r requirements/test.txt
 git+https://github.com/edx/credentials-themes.git@0.1.46#egg=edx_credentials_themes==0.1.46  # via -r requirements/test.txt
-factory-boy==3.1.0        # via -r requirements/test.txt
-faker==5.0.2              # via -r requirements/test.txt, factory-boy
+factory-boy==3.2.0        # via -r requirements/test.txt
+faker==5.3.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
-gitpython==3.1.11         # via -r requirements/test.txt, transifex-client
-httpretty==1.0.3          # via -r requirements/test.txt
+gitpython==3.1.12         # via -r requirements/test.txt, transifex-client
+httpretty==1.0.5          # via -r requirements/test.txt
 idna==2.10                # via -r requirements/test.txt, requests
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
@@ -77,8 +77,8 @@ lazy==1.4                 # via -r requirements/test.txt, bok-choy
 markdown==3.3.3           # via -r requirements/test.txt
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mysqlclient==2.0.2        # via -r requirements/test.txt
-newrelic==5.22.1.152      # via -r requirements/test.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/test.txt
+newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.8           # via -r requirements/test.txt, bleach, pytest, tox
@@ -86,10 +86,10 @@ paramiko==2.7.2           # via docker
 path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
 path==15.0.1              # via -r requirements/test.txt, path.py
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
-pillow==8.0.1             # via -r requirements/test.txt
+pillow==8.1.0             # via -r requirements/test.txt
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
-psutil==5.7.3             # via -r requirements/test.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
 py==1.10.0                # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/test.txt
 pycparser==2.20           # via -r requirements/test.txt, cffi
@@ -100,7 +100,7 @@ pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-back
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/test.txt, edx-opaque-keys
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
@@ -112,7 +112,7 @@ python-dotenv==0.15.0     # via docker-compose
 python-memcached==1.59    # via -r requirements/test.txt
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations, transifex-client
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
-pytz==2020.4              # via -r requirements/test.txt, django
+pytz==2020.5              # via -r requirements/test.txt, django
 pywatchman==1.4.1 ; "linux" in sys_platform  # via -r requirements/dev.in
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, docker-compose, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
@@ -126,7 +126,7 @@ simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger, s
 six==1.15.0               # via -r requirements/test.txt, analytics-python, astroid, bcrypt, bleach, bok-choy, cryptography, django-compat, django-simple-history, docker, dockerpty, edx-ace, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, jsonschema, pyjwkest, pynacl, python-dateutil, python-memcached, responses, social-auth-app-django, social-auth-core, tox, transifex-client, virtualenv, websocket-client
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
+social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/test.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/test.txt, code-annotations, edx-ace, edx-django-utils, edx-opaque-keys

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ code-annotations==0.10.2  # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
 coverage==5.3             # via -r requirements/test.txt
-cryptography==3.3.1       # via -r requirements/test.txt, paramiko, pyjwt
+cryptography==3.3.1       # via -r requirements/test.txt, paramiko, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.txt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
@@ -127,7 +127,7 @@ six==1.15.0               # via -r requirements/test.txt, analytics-python, astr
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/test.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/test.txt, code-annotations, edx-ace, edx-django-utils, edx-opaque-keys
 testfixtures==6.17.0      # via -r requirements/test.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -9,7 +9,7 @@ babel==2.9.0              # via sphinx
 certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 docutils==0.16            # via sphinx
-edx-sphinx-theme==1.5.0   # via -r requirements/docs.in
+edx-sphinx-theme==1.6.0   # via -r requirements/docs.in
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via sphinx
@@ -17,11 +17,11 @@ markupsafe==1.1.1         # via jinja2
 packaging==20.8           # via sphinx
 pygments==2.7.3           # via sphinx
 pyparsing==2.4.7          # via packaging
-pytz==2020.4              # via babel
+pytz==2020.5              # via babel
 requests==2.24.0          # via -c requirements/constraints.txt, sphinx
 six==1.15.0               # via edx-sphinx-theme
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.3.1             # via -r requirements/docs.in, edx-sphinx-theme
+sphinx==3.4.2             # via -r requirements/docs.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,8 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.4.0          # via -r requirements/pip_tools.in
-six==1.15.0               # via pip-tools
+pip-tools==5.5.0          # via -r requirements/pip_tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -7,8 +7,8 @@
 analytics-python==1.2.9   # via -r requirements/base.txt
 attrs==20.3.0             # via -r requirements/base.txt, edx-ace
 bleach==3.2.1             # via -r requirements/base.txt
-boto3==1.16.38            # via django-ses
-botocore==1.19.38         # via boto3, s3transfer
+boto3==1.16.50            # via django-ses
+botocore==1.19.50         # via boto3, s3transfer
 certifi==2020.12.5        # via -r requirements/base.txt, requests
 cffi==1.14.4              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
@@ -29,7 +29,7 @@ django-ses==1.0.3         # via -r requirements/production.in
 django-simple-history==2.12.0  # via -r requirements/base.txt
 django-sortedm2m==3.0.2   # via -r requirements/base.txt
 django-statici18n==2.0.1  # via -r requirements/base.txt
-django-storages==1.11     # via -r requirements/base.txt
+django-storages==1.11.1   # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/base.txt
 django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-crum, django-debug-toolbar, django-filter, django-ses, django-statici18n, django-storages, djangorestframework, drf-jwt, edx-ace, edx-auth-backends, edx-credentials-themes, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, xss-utils
@@ -46,9 +46,9 @@ edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rest-api-client==5.2.2  # via -r requirements/base.txt
 git+https://github.com/edx/credentials-themes.git@0.1.46#egg=edx_credentials_themes==0.1.46  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, django-ses, pyjwkest
-gevent==20.9.0            # via -r requirements/production.in
+gevent==20.12.1           # via -r requirements/production.in
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
-gitpython==3.1.11         # via -r requirements/base.txt, transifex-client
+gitpython==3.1.12         # via -r requirements/base.txt, transifex-client
 greenlet==0.4.17          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 idna==2.10                # via -r requirements/base.txt, requests
@@ -57,8 +57,8 @@ jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jmespath==0.10.0          # via boto3, botocore
 markdown==3.3.3           # via -r requirements/base.txt
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mysqlclient==2.0.2        # via -r requirements/base.txt
-newrelic==5.22.1.152      # via -r requirements/base.txt, -r requirements/production.in, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, -r requirements/production.in, edx-django-utils
 nodeenv==1.5.0            # via -r requirements/production.in
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
@@ -66,9 +66,9 @@ packaging==20.8           # via -r requirements/base.txt, bleach
 path.py==12.5.0           # via -r requirements/base.txt, edx-i18n-tools
 path==15.0.1              # via -r requirements/base.txt, path.py
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
-pillow==8.0.1             # via -r requirements/base.txt
+pillow==8.1.0             # via -r requirements/base.txt
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
-psutil==5.7.3             # via -r requirements/base.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
 pygments==2.7.3           # via -r requirements/base.txt
@@ -80,7 +80,7 @@ python-dateutil==2.8.1    # via -r requirements/base.txt, analytics-python, boto
 python-memcached==1.59    # via -r requirements/base.txt
 python-slugify==4.0.1     # via -r requirements/base.txt, transifex-client
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.4              # via -r requirements/base.txt, django, django-ses
+pytz==2020.5              # via -r requirements/base.txt, django, django-ses
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -c requirements/constraints.txt, -r requirements/base.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, sailthru-client, slumber, social-auth-core, transifex-client
@@ -92,7 +92,7 @@ simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger, s
 six==1.15.0               # via -r requirements/base.txt, analytics-python, bleach, cryptography, django-compat, django-simple-history, edx-ace, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, transifex-client
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/base.txt, edx-ace, edx-django-utils, edx-opaque-keys

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,7 +14,7 @@ cffi==1.14.4              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.3.1       # via -r requirements/base.txt, pyjwt
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-appconf==1.0.4     # via -r requirements/base.txt, django-statici18n
 django-compat==1.0.15     # via -r requirements/base.txt, django-hijack
@@ -93,7 +93,7 @@ six==1.15.0               # via -r requirements/base.txt, analytics-python, blea
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/base.txt, edx-ace, edx-django-utils, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/base.txt, python-slugify

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ click==7.1.2              # via click-log, code-annotations, edx-lint
 code-annotations==0.10.2  # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.3             # via -r requirements/test.in
+coverage==5.3.1           # via -r requirements/test.in
 cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
@@ -35,7 +35,7 @@ django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.12.0  # via -r requirements/base.txt
 django-sortedm2m==3.0.2   # via -r requirements/base.txt
 django-statici18n==2.0.1  # via -r requirements/base.txt
-django-storages==1.11     # via -r requirements/base.txt
+django-storages==1.11.1   # via -r requirements/base.txt
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/base.txt
 djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition
@@ -47,17 +47,17 @@ edx-django-sites-extensions==2.5.1  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt, edx-credentials-themes
-edx-lint==1.5.2           # via -r requirements/test.in
+edx-lint==1.5.2           # via -c requirements/constraints.txt, -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rest-api-client==5.2.2  # via -r requirements/base.txt
 git+https://github.com/edx/credentials-themes.git@0.1.46#egg=edx_credentials_themes==0.1.46  # via -r requirements/base.txt
-factory-boy==3.1.0        # via -r requirements/test.in
-faker==5.0.2              # via factory-boy
+factory-boy==3.2.0        # via -r requirements/test.in
+faker==5.3.0              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
-gitpython==3.1.11         # via -r requirements/base.txt, transifex-client
-httpretty==1.0.3          # via -r requirements/test.in
+gitpython==3.1.12         # via -r requirements/base.txt, transifex-client
+httpretty==1.0.5          # via -r requirements/test.in
 idna==2.10                # via -r requirements/base.txt, requests
 iniconfig==1.1.1          # via pytest
 isort==4.3.21             # via -r requirements/test.in, pylint
@@ -68,18 +68,18 @@ lazy==1.4                 # via bok-choy
 markdown==3.3.3           # via -r requirements/base.txt
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mysqlclient==2.0.2        # via -r requirements/base.txt
-newrelic==5.22.1.152      # via -r requirements/base.txt, edx-django-utils
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.8           # via -r requirements/base.txt, bleach, pytest, tox
 path.py==12.5.0           # via -r requirements/base.txt, edx-i18n-tools
 path==15.0.1              # via -r requirements/base.txt, path.py
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
-pillow==8.0.1             # via -r requirements/base.txt
+pillow==8.1.0             # via -r requirements/base.txt
 pluggy==0.13.1            # via pytest, tox
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
-psutil==5.7.3             # via -r requirements/base.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 py==1.10.0                # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/test.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
@@ -90,7 +90,7 @@ pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-back
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -c requirements/constraints.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 pytest-django==4.1.0      # via -r requirements/test.in
@@ -99,7 +99,7 @@ python-dateutil==2.8.1    # via -r requirements/base.txt, analytics-python, edx-
 python-memcached==1.59    # via -r requirements/base.txt
 python-slugify==4.0.1     # via -r requirements/base.txt, code-annotations, transifex-client
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.4              # via -r requirements/base.txt, django
+pytz==2020.5              # via -r requirements/base.txt, django
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -c requirements/constraints.txt, -r requirements/base.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, sailthru-client, slumber, social-auth-core, transifex-client
@@ -112,7 +112,7 @@ simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger, s
 six==1.15.0               # via -r requirements/base.txt, analytics-python, astroid, bleach, bok-choy, cryptography, django-compat, django-simple-history, edx-ace, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, pyjwkest, python-dateutil, python-memcached, responses, social-auth-app-django, social-auth-core, tox, transifex-client, virtualenv
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/base.txt, code-annotations, edx-ace, edx-django-utils, edx-opaque-keys

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ code-annotations==0.10.2  # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 coverage==5.3             # via -r requirements/test.in
-cryptography==3.3.1       # via -r requirements/base.txt, pyjwt
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 distlib==0.3.1            # via virtualenv
@@ -113,7 +113,7 @@ six==1.15.0               # via -r requirements/base.txt, analytics-python, astr
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/base.txt, code-annotations, edx-ace, edx-django-utils, edx-opaque-keys
 testfixtures==6.17.0      # via -r requirements/test.in


### PR DESCRIPTION
The bug mentioned on [ARCHBOM-1078](https://openedx.atlassian.net/browse/ARCHBOM-1078) is fixed in `social-auth-core==3.3.3`, See [this comment](https://openedx.atlassian.net/browse/BOM-2094?focusedCommentId=514498) for details, now we are unpinning it wherever it was previously pinned due to that bug.
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2183