### PR TITLE
MICROBA-994 Use gettext_lazy to defer translation until used in template

### DIFF
--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import slugify
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
 from credentials.apps.catalog.data import OrganizationDetails, ProgramDetails


### PR DESCRIPTION
[MICROBA-994](https://openedx.atlassian.net/browse/MICROBA-994)

You can read more about lazy translation here: https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#lazy-translation

**The problem**
One particular string on program certificates configured to use Spanish is not being translated into Spanish.

**The solution**
That particular string is constructed in the view rather than the template. It was getting translated before/without knowing what language is set from the program certificate configuration. Using this "lazy translation" tells this string to wait to be translated until actually used in the template, at which point it knows about which language it’s supposed to use from the configuration.