### PR TITLE
Remove dependencyDashboard since credentials doesn't use issues

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,6 @@
     }
   ],
   "prConcurrentLimit": 5,
-  "dependencyDashboard": true,
   "rebaseWhen": "behind-base-branch",
   "schedule": [
     "before 6am every weekday"


### PR DESCRIPTION
The _dependencyDashboard_ setting creates an issue with an overview dashboard. Since credentials doesn't use issues (we track things in jira), it didn't seem to have any effect. I'm suggesting we remove it for simplicity.

Doc: https://docs.renovatebot.com/configuration-options/#dependencydashboard