### PR TITLE
Pin edx-ace to a version that won't break us

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,3 +25,7 @@ social-auth-core<4.0.3
 # New versions of this package are breaking authentication in this service.
 # this is a temporary constraint until we can isolate and resolve the issue.
 edx-auth-backends<=3.3.0
+
+# Newer versions require passing in lms_user_id rather than a username.
+# Ticket for adding LMS user IDs to Credentials: https://openedx.atlassian.net/browse/MICROBA-649
+edx-ace<1.0.0


### PR DESCRIPTION
Version 1.0.0 is not released yet. This is just in advance.

Fixing https://openedx.atlassian.net/browse/MICROBA-649 should let us unpin it.