### PR TITLE
Add deletions to copy_catalog command

### DIFF
--- a/acceptance_tests/pages.py
+++ b/acceptance_tests/pages.py
@@ -8,7 +8,7 @@ CREDENTIALS_ROOT_URL = os.environ.get("CREDENTIALS_ROOT_URL", "http://localhost:
 
 class BasePage(PageObject):  # pylint: disable=abstract-method
     @unguarded
-    def wait_for_page(self, *args, **kwargs):  # pylint: disable=signature-differs
+    def wait_for_page(self, *args, **kwargs):
         super().wait_for_page(*args, **kwargs)
 
         # Bokchoy's wait_for_page call does an accessibility check automatically (if VERIFY_ACCESSIBILITY is on).

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -23,8 +23,6 @@ from credentials.apps.records.models import UserGrade
 
 log = logging.getLogger(__name__)
 
-# pylint: disable= no-member
-
 
 def credentials_throttle_handler(exc, context):
     """ Exception handler for logging messages when an endpoint is throttled. """

--- a/credentials/apps/catalog/management/commands/copy_catalog.py
+++ b/credentials/apps/catalog/management/commands/copy_catalog.py
@@ -1,12 +1,11 @@
 """ Copy catalog data from Discovery. """
 
 import logging
-from urllib.parse import urljoin
 
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
 
-from credentials.apps.catalog.utils import parse_pathway, parse_program
+from credentials.apps.catalog.utils import CatalogDataSynchronizer
 from credentials.apps.core.models import SiteConfiguration
 
 
@@ -27,9 +26,17 @@ class Command(BaseCommand):
             default=None,
             help="The maximum number of catalog items to request at once.",
         )
+        parser.add_argument(
+            "--delete",
+            action="store_true",
+            dest="delete_data",
+            required=False,
+            help="Delete catalog data that doesn't exist in Discovery service",
+        )
 
     def handle(self, *args, **options):
         page_size = options.get("page_size")
+        delete_data = options.get("delete_data")
 
         for site in Site.objects.all():
             site_configs = SiteConfiguration.objects.filter(site=site)
@@ -41,40 +48,12 @@ class Command(BaseCommand):
                 logger.info(f"Skipping site {site.domain}. No configuration.")
                 continue
 
-            logger.info(f"Copying catalog data for site {site.domain}")
-            Command.fetch_programs(site, site_config, page_size=page_size)
-            logger.info("Finished copying programs.")
-            Command.fetch_pathways(site, site_config, page_size=page_size)
-            logger.info("Finished copying pathways.")
-
-    @staticmethod
-    def fetch_programs(site, site_config, page_size=None):
-        api_client = site_config.api_client
-        programs_url = urljoin(site_config.catalog_api_url, "programs/")
-        next_page = 1
-        while next_page:
-            response = api_client.get(
-                programs_url, params={"exclude_utm": 1, "page": next_page, "page_size": page_size}
+            synchronizer = CatalogDataSynchronizer(
+                site=site,
+                api_client=site_config.api_client,
+                catalog_api_url=site_config.catalog_api_url,
+                page_size=page_size,
             )
-            response.raise_for_status()
-            programs = response.json()
-            for program in programs["results"]:
-                logger.info(f'Copying program "{program["title"]}"')
-                parse_program(site, program)
-            next_page = next_page + 1 if programs["next"] else None
-
-    @staticmethod
-    def fetch_pathways(site, site_config, page_size=None):
-        api_client = site_config.api_client
-        pathways_url = urljoin(site_config.catalog_api_url, "pathways/")
-        next_page = 1
-        while next_page:
-            response = api_client.get(
-                pathways_url, params={"exclude_utm": 1, "page": next_page, "page_size": page_size}
-            )
-            response.raise_for_status()
-            pathways = response.json()
-            for pathway in pathways["results"]:
-                logger.info(f'Copying pathway "{pathway["name"]}"')
-                parse_pathway(site, pathway)
-            next_page = next_page + 1 if pathways["next"] else None
+            synchronizer.fetch_data()
+            if delete_data:
+                synchronizer.remove_externally_deleted_data()

--- a/credentials/apps/catalog/utils.py
+++ b/credentials/apps/catalog/utils.py
@@ -53,7 +53,7 @@ class CatalogDataSynchronizer:
 
     def remove_externally_deleted_data(self):
         """Removes data that was deleted out of the Discovery service"""
-        for model_type in self.existing_data.keys():
+        for model_type in self.existing_data:
             removed = self.existing_data_sets[model_type] - self.updated_data_sets[model_type]
             if removed:
                 logger.info(f"Removing the following {model_type} UUIDs: {removed}")
@@ -75,7 +75,6 @@ class CatalogDataSynchronizer:
             next_page = next_page + 1 if programs["next"] else None
 
     def _fetch_pathways(self):
-        api_client = self.api_client
         pathways_url = urljoin(self.catalog_api_url, "pathways/")
         next_page = 1
         while next_page:
@@ -92,7 +91,7 @@ class CatalogDataSynchronizer:
     def _log_changes(self):
         """Prints out the what data will be added and what will be deleted"""
         logger.info("The copy_catalog command caused the following changes:")
-        for model_type in self.existing_data.keys():
+        for model_type in self.existing_data:
             added = [str(_uuid) for _uuid in self.updated_data_sets[model_type] - self.existing_data_sets[model_type]]
             to_be_removed = [
                 str(_uuid) for _uuid in self.existing_data_sets[model_type] - self.updated_data_sets[model_type]

--- a/credentials/apps/catalog/utils.py
+++ b/credentials/apps/catalog/utils.py
@@ -1,30 +1,167 @@
 """Utilities for integration with the catalog service."""
+import logging
+from urllib.parse import urljoin
 
 from django.db import transaction
 
 from credentials.apps.catalog.models import Course, CourseRun, Organization, Pathway, Program
 
 
-# Note: these parsing functions don't attempt to clear out old data that is no longer provided by Discovery.
-# That shouldn't normally happen (ideally content just gets archived, not deleted).
-# Having broken links in our DB would be hard to deal with, so for now, we just leave any old objects around
-# and don't worry about matching current Discovery state exactly.
+logger = logging.getLogger(__name__)
 
 
-def parse_organization(site, data):
-    org, _ = Organization.objects.update_or_create(
+class CatalogDataSynchronizer:
+    COURSE = "course"
+    COURSE_RUN = "course_run"
+    ORGANIZATION = "organization"
+    PATHWAY = "pathway"
+    PROGRAM = "program"
+
+    def __init__(self, site, api_client, catalog_api_url, page_size):
+        self.site = site
+        self.api_client = api_client
+        self.catalog_api_url = catalog_api_url
+        self.page_size = page_size
+        self.existing_data = {
+            self.COURSE: Course.objects.filter(site=site),
+            self.COURSE_RUN: CourseRun.objects.filter(course__site=site),
+            self.ORGANIZATION: Organization.objects.filter(site=site),
+            self.PATHWAY: Pathway.objects.filter(site=site),
+            self.PROGRAM: Program.objects.filter(site=site),
+        }
+        self.updated_data_sets = {
+            self.COURSE: set(),
+            self.COURSE_RUN: set(),
+            self.ORGANIZATION: set(),
+            self.PATHWAY: set(),
+            self.PROGRAM: set(),
+        }
+        self.existing_data_sets = {
+            model: set(queryset.values_list("uuid", flat=True)) for (model, queryset) in self.existing_data.items()
+        }
+
+    def add_item(self, model_type, value):
+        self.updated_data_sets[model_type].add(value)
+
+    def fetch_data(self):
+        logger.info(f"Copying catalog data for site {self.site.domain}")
+        self._fetch_programs()
+        logger.info("Finished copying programs.")
+        self._fetch_pathways()
+        logger.info("Finished copying pathways.")
+        self._log_changes()
+
+    def remove_externally_deleted_data(self):
+        """Removes data that was deleted out of the Discovery service"""
+        for model_type in self.existing_data.keys():
+            removed = self.existing_data_sets[model_type] - self.updated_data_sets[model_type]
+            if removed:
+                logger.info(f"Removing the following {model_type} UUIDs: {removed}")
+                self.existing_data[model_type].filter(uuid__in=removed).delete()
+
+    def _fetch_programs(self):
+        programs_url = urljoin(self.catalog_api_url, "programs/")
+        next_page = 1
+        while next_page:
+            response = self.api_client.get(
+                programs_url, params={"exclude_utm": 1, "page": next_page, "page_size": self.page_size}
+            )
+            response.raise_for_status()
+            programs = response.json()
+            for program in programs["results"]:
+                logger.info(f'Copying program "{program["title"]}"')
+                parse_program(self.site, program, self)
+
+            next_page = next_page + 1 if programs["next"] else None
+
+    def _fetch_pathways(self):
+        api_client = self.api_client
+        pathways_url = urljoin(self.catalog_api_url, "pathways/")
+        next_page = 1
+        while next_page:
+            response = self.api_client.get(
+                pathways_url, params={"exclude_utm": 1, "page": next_page, "page_size": self.page_size}
+            )
+            response.raise_for_status()
+            pathways = response.json()
+            for pathway in pathways["results"]:
+                logger.info(f'Copying pathway "{pathway["name"]}"')
+                parse_pathway(self.site, pathway, self)
+            next_page = next_page + 1 if pathways["next"] else None
+
+    def _log_changes(self):
+        """Prints out the what data will be added and what will be deleted"""
+        logger.info("The copy_catalog command caused the following changes:")
+        for model_type in self.existing_data.keys():
+            added = [str(_uuid) for _uuid in self.updated_data_sets[model_type] - self.existing_data_sets[model_type]]
+            to_be_removed = [
+                str(_uuid) for _uuid in self.existing_data_sets[model_type] - self.updated_data_sets[model_type]
+            ]
+            if added:
+                logger.info(f"{model_type} UUIDs added: {added}")
+            if to_be_removed:
+                logger.info(f"{model_type} UUIDs to be removed: {to_be_removed if to_be_removed else None}")
+
+
+@transaction.atomic
+def parse_program(site, data, synchronizer=None):
+    program, _ = Program.objects.update_or_create(
+        site=site,
+        uuid=data["uuid"],
+        defaults={
+            "title": data["title"],
+            "type": data["type"],
+            "status": data["status"],
+            "type_slug": data["type_attrs"]["slug"],
+            "total_hours_of_effort": data["total_hours_of_effort"],
+        },
+    )
+    if synchronizer:
+        synchronizer.add_item(synchronizer.PROGRAM, program.uuid)
+
+    program.authoring_organizations.clear()
+    for org_data in data["authoring_organizations"]:
+        org = parse_organization(site, org_data, synchronizer)
+        program.authoring_organizations.add(org)
+
+    program.course_runs.clear()
+    for course_data in data["courses"]:
+        _, course_runs = parse_course(site, course_data, synchronizer)
+        program.course_runs.add(*course_runs)
+
+    return program
+
+
+@transaction.atomic
+def parse_course(site, data, synchronizer=None):
+    course, _ = Course.objects.update_or_create(
         site=site,
         uuid=data["uuid"],
         defaults={
             "key": data["key"],
-            "name": data["name"],
-            "certificate_logo_image_url": data["certificate_logo_image_url"],
+            "title": data["title"],
         },
     )
-    return org
+
+    if synchronizer:
+        synchronizer.add_item(synchronizer.COURSE, course.uuid)
+
+    course.owners.clear()
+    for org_data in data["owners"]:
+        org = parse_organization(site, org_data, synchronizer)
+        course.owners.add(org)
+
+    course_runs = []
+    for run_data in data["course_runs"]:
+        course_run = parse_course_run(course, run_data, synchronizer)
+        course.course_runs.add(course_run)
+        course_runs.append(course_run)
+
+    # We count course_runs separately, since some programs may not have all runs that a course does
+    return course, course_runs
 
 
-def parse_course_run(course, data):
+def parse_course_run(course, data, synchronizer=None):
     course_run, _ = CourseRun.objects.update_or_create(
         course=course,
         uuid=data["uuid"],
@@ -40,64 +177,28 @@ def parse_course_run(course, data):
             "end_date": data["end_date"] if "end_date" in data else data["end"],
         },
     )
+    if synchronizer:
+        synchronizer.add_item(synchronizer.COURSE_RUN, course_run.uuid)
     return course_run
 
 
-@transaction.atomic
-def parse_course(site, data):
-    course, _ = Course.objects.update_or_create(
+def parse_organization(site, data, synchronizer=None):
+    org, _ = Organization.objects.update_or_create(
         site=site,
         uuid=data["uuid"],
         defaults={
             "key": data["key"],
-            "title": data["title"],
+            "name": data["name"],
+            "certificate_logo_image_url": data["certificate_logo_image_url"],
         },
     )
-
-    course.owners.clear()
-    for org_data in data["owners"]:
-        org = parse_organization(site, org_data)
-        course.owners.add(org)
-
-    course_runs = []
-    for run_data in data["course_runs"]:
-        course_run = parse_course_run(course, run_data)
-        course.course_runs.add(course_run)
-        course_runs.append(course_run)
-
-    # We count course_runs separately, since some programs may not have all runs that a course does
-    return course, course_runs
+    if synchronizer:
+        synchronizer.add_item(synchronizer.ORGANIZATION, org.uuid)
+    return org
 
 
 @transaction.atomic
-def parse_program(site, data):
-    program, _ = Program.objects.update_or_create(
-        site=site,
-        uuid=data["uuid"],
-        defaults={
-            "title": data["title"],
-            "type": data["type"],
-            "status": data["status"],
-            "type_slug": data["type_attrs"]["slug"],
-            "total_hours_of_effort": data["total_hours_of_effort"],
-        },
-    )
-
-    program.authoring_organizations.clear()
-    for org_data in data["authoring_organizations"]:
-        org = parse_organization(site, org_data)
-        program.authoring_organizations.add(org)
-
-    program.course_runs.clear()
-    for course_data in data["courses"]:
-        _, course_runs = parse_course(site, course_data)
-        program.course_runs.add(*course_runs)
-
-    return program
-
-
-@transaction.atomic
-def parse_pathway(site, data):
+def parse_pathway(site, data, synchronizer=None):
     """
     Assumes that the associated programs were parsed before this is run.
     """
@@ -111,6 +212,9 @@ def parse_pathway(site, data):
             "pathway_type": data["pathway_type"],
         },
     )
+
+    if synchronizer:
+        synchronizer.add_item(synchronizer.PATHWAY, pathway.uuid)
 
     pathway.programs.clear()
     for program_data in data["programs"]:


### PR DESCRIPTION
The copy_catalog management command now had optional deletions if you pass the `--delete` flag. This will propogate Discovery deletions into Credentials.

This does **not** currently do any checks on related models. It simply deletes the object or doesn't (depending on the `--delete` flag). The only `CASCADE` we have currently is that a CourseRun will be deleted if we delete the related Course. 