### PR TITLE
MB-849: Improve credentials usability in devstack

### DIFF
--- a/credentials/apps/credentials/management/commands/create_program_certificate_configuration.py
+++ b/credentials/apps/credentials/management/commands/create_program_certificate_configuration.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
     """
     Management command to create a program certificate configuration for the demo program.
-    This is meant to be ran from a provisioning script for devstack and not by hand.
+    This is meant to be run from a provisioning script for devstack and not by hand.
     """
 
     def add_arguments(self, parser):

--- a/credentials/apps/credentials/management/commands/create_program_certificate_configuration.py
+++ b/credentials/apps/credentials/management/commands/create_program_certificate_configuration.py
@@ -1,0 +1,42 @@
+""" Management command to create a program certificate configuration for the demo program """
+import logging
+
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand, CommandError
+
+from credentials.apps.catalog.models import Program
+from credentials.apps.credentials.models import ProgramCertificate
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command to create a program certificate configuration for the demo program.
+    This is meant to be ran from a provisioning script for devstack and not by hand.
+    """
+
+    def add_arguments(self, parser):
+        """ Arguments for the command. defaults are the demo program for devstack """
+        parser.add_argument("--domain-name", default="example.com")
+        parser.add_argument("--program-name", default="edX Demonstration Program")
+
+    def handle(self, *args, **kwargs):
+        site_domain = kwargs.get("domain_name")
+        program_name = kwargs.get("program_name")
+        try:
+            ProgramCertificate.objects.get_or_create(
+                site=Site.objects.get(domain=site_domain),
+                program_uuid=self.get_example_program_uuid(program_name),
+                is_active=True,
+            )
+        except Exception as e:
+            raise CommandError(e)
+
+    def get_example_program_uuid(self, program_name):
+        try:
+            demo_program = Program.objects.get(title=program_name)
+            return demo_program.uuid
+        except Program.DoesNotExist:
+            raise CommandError("The demo program either doesn't exist or is not yet in the catalogue")

--- a/credentials/apps/credentials/management/commands/tests/test_create_program_certificate_configuration.py
+++ b/credentials/apps/credentials/management/commands/tests/test_create_program_certificate_configuration.py
@@ -1,0 +1,50 @@
+"""
+Tests for the create_program_certificate_configuration command
+"""
+
+from unittest import TestCase, mock
+
+import pytest
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from credentials.apps.catalog.models import Program
+from credentials.apps.catalog.tests.factories import (
+    CourseFactory,
+    CourseRunFactory,
+    OrganizationFactory,
+    ProgramFactory,
+)
+from credentials.apps.credentials.models import ProgramCertificate
+
+
+COMMAND = "create_program_certificate_configuration"
+
+
+@pytest.mark.django_db
+class CertAllowlistGenerationTests(TestCase):
+    """
+    Tests for the create_credentials_api_configuration management command
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.site = Site.objects.get(domain="example.com")
+        new_course = CourseFactory.create(site=self.site)
+        self.new_course_run = CourseRunFactory.create(course=new_course)
+        self.orgs = [OrganizationFactory.create(name=name, site=self.site) for name in ["TestOrg1", "TestOrg2"]]
+
+    def test_successful_generation(self):
+        ProgramFactory.create(
+            title="edX Demonstration Program",
+            course_runs=[self.new_course_run],
+            authoring_organizations=self.orgs,
+            site=self.site,
+        )
+        call_command(command_name=COMMAND)
+        assert len(ProgramCertificate.objects.all()) > 0
+
+    def test_errors_when_demo_program_is_not_in_catalog(self):
+        with pytest.raises(CommandError):
+            call_command(command_name=COMMAND)


### PR DESCRIPTION
feat: Add command to create program cert config

This adds a command to create a program certificate configuration for the demo program. This command is meant to be used by a provisioning script, and not ran by hand. This command will not work unless the demo program is in the catalog.