### PR TITLE
fix: Request hidden course runs

### DIFF
--- a/credentials/apps/catalog/tests/test_utils.py
+++ b/credentials/apps/catalog/tests/test_utils.py
@@ -98,7 +98,9 @@ class SynchronizerTests(TestCase):
         # Indexes into API_RESPONSES
         self.api_call_count = 0
 
-    def _mock_fetch_resource(self, resource_name, parse_method):
+    def _mock_fetch_resource(
+        self, resource_name, parse_method, extra_request_params=None
+    ):  # pylint: disable=unused-argument
         data = self.API_RESPONSES[self.api_call_count].get(resource_name)
         if data:
             parse_method(data)


### PR DESCRIPTION
Not all course runs were being returned on the courses API. We have to add this extra parameter to get them.