### PR TITLE
refactor: Remove get_program and it's callers

### DIFF
--- a/credentials/apps/core/models.py
+++ b/credentials/apps/core/models.py
@@ -148,34 +148,6 @@ class SiteConfiguration(models.Model):
             settings.BACKEND_SERVICE_EDX_OAUTH2_SECRET,
         )
 
-    def get_program(self, program_uuid, ignore_cache=False):
-        """
-        Retrieves the details for the specified program.
-
-         Args:
-             program_uuid (UUID): Program identifier
-             ignore_cache (bool): Indicates if previously-cached data should be ignored.
-
-         Returns:
-             dict
-        """
-        program_uuid = str(program_uuid)
-        cache_key = f"programs.api.data.{program_uuid}"
-
-        if not ignore_cache:
-            program = cache.get(cache_key)
-
-            if program:
-                return program
-
-        program_url = urljoin(self.catalog_api_url, f"programs/{program_uuid}/")
-        response = self.api_client.get(program_url)
-        response.raise_for_status()
-        program = response.json()
-        cache.set(cache_key, program, settings.PROGRAMS_CACHE_TTL)
-
-        return program
-
     def get_user_api_data(self, username):
         """Retrieve details for the specified user from the User API.
 

--- a/credentials/apps/core/tests/test_models.py
+++ b/credentials/apps/core/tests/test_models.py
@@ -1,6 +1,5 @@
 """ Tests for core models. """
 import json
-import uuid
 from unittest import mock
 
 import responses
@@ -43,43 +42,6 @@ class SiteConfigurationTests(SiteMixin, TestCase):
         site = SiteFactory(domain="test.org", name="test")
         site_configuration = SiteConfigurationFactory(site=site)
         self.assertEqual(str(site_configuration), site.name)
-
-    @responses.activate
-    def test_get_program(self):
-        """ Verify the method retrieves program data from the Catalog API. """
-        program_uuid = uuid.uuid4()
-        program_endpoint = f"programs/{program_uuid}/"
-        body = {
-            "uuid": program_uuid.hex,
-            "title": "A Fake Program",
-            "type": "fake",
-            "authoring_organizations": [
-                {
-                    "uuid": uuid.uuid4().hex,
-                    "key": "FakeX",
-                    "name": "Fake University",
-                    "logo_image_url": "https://static.fake.edu/logo.png",
-                }
-            ],
-            "courses": [],
-        }
-
-        self.mock_access_token_response()
-        self.mock_catalog_api_response(program_endpoint, body)
-        self.assertEqual(self.site_configuration.get_program(program_uuid), body)
-        self.assertEqual(len(responses.calls), 2)
-
-        # Verify the data is cached
-        responses.reset()
-        self.assertEqual(self.site_configuration.get_program(program_uuid), body)
-        self.assertEqual(self.site_configuration.get_program(program_uuid), body)
-        self.assertEqual(len(responses.calls), 0)
-
-        # Verify the cache can be bypassed
-        self.mock_access_token_response()
-        self.mock_catalog_api_response(program_endpoint, body)
-        self.assertEqual(self.site_configuration.get_program(program_uuid, ignore_cache=True), body)
-        self.assertEqual(len(responses.calls), 1)
 
     def test_clear_site_cache_on_db_write(self):
         """Verify the site cache is cleared whenever a SiteConfiguration instance is

--- a/credentials/apps/credentials/forms.py
+++ b/credentials/apps/credentials/forms.py
@@ -7,6 +7,7 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
+from credentials.apps.catalog.api import get_program_details_by_uuid
 from credentials.apps.credentials.models import ProgramCertificate, Signatory
 
 
@@ -36,11 +37,11 @@ class ProgramCertificateAdminForm(forms.ModelForm):
 
         site = cleaned_data["site"]
         program_uuid = cleaned_data["program_uuid"]
-        program = site.siteconfiguration.get_program(program_uuid, ignore_cache=True)
+        program = get_program_details_by_uuid(program_uuid, site)
 
         # Ensure the program's authoring organizations all have certificate logos
-        for organization in program.get("authoring_organizations", []):
-            if not organization.get("certificate_logo_image_url"):
+        for organization in program.organizations:
+            if not organization.certificate_logo_image_url:
                 self.add_error(
                     "program_uuid",
                     _("All authoring organizations of the program MUST have a certificate image defined!"),

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -266,10 +266,6 @@ class ProgramCertificate(AbstractCertificate):
         verbose_name = "Program certificate configuration"
         unique_together = (("site", "program_uuid"),)
 
-    def get_program_api_data(self):
-        """ Returns program data from the Catalog API. """
-        return self.site.siteconfiguration.get_program(self.program_uuid)  # pylint: disable=no-member
-
     @cached_property
     def program_details(self):
         """ Returns details about the program associated with this certificate. """

--- a/credentials/apps/credentials/tests/test_forms.py
+++ b/credentials/apps/credentials/tests/test_forms.py
@@ -1,31 +1,17 @@
+import dataclasses
 from unittest import mock
 
 import factory
+import faker
 from django.test import TestCase
 
-from credentials.apps.core.models import SiteConfiguration
+from credentials.apps.catalog.data import OrganizationDetails, ProgramDetails
 from credentials.apps.core.tests.factories import SiteConfigurationFactory
 from credentials.apps.credentials.forms import ProgramCertificateAdminForm
 from credentials.apps.credentials.tests.factories import ProgramCertificateFactory
 
 
 class ProgramCertificateAdminFormTests(TestCase):
-    BAD_MOCK_API_PROGRAM = {
-        "authoring_organizations": [
-            {
-                "certificate_logo_image_url": None,
-            }
-        ],
-    }
-
-    GOOD_MOCK_API_PROGRAM = {
-        "authoring_organizations": [
-            {
-                "certificate_logo_image_url": "https://example.com",
-            }
-        ],
-    }
-
     def test_program_uuid(self):
         """Verify a ValidationError is raised if the program's authoring organizations have
         no certificate images."""
@@ -34,18 +20,43 @@ class ProgramCertificateAdminFormTests(TestCase):
         data["site"] = sc.site.id
 
         form = ProgramCertificateAdminForm(data)
-        with mock.patch.object(SiteConfiguration, "get_program", return_value=self.BAD_MOCK_API_PROGRAM) as mock_method:
+        fake = faker.Faker()
+
+        bad_organization = OrganizationDetails(
+            uuid=fake.uuid4(),
+            key=fake.word(),
+            name=fake.word(),
+            display_name=fake.word(),
+            certificate_logo_image_url=None,
+        )
+        good_organization = dataclasses.replace(bad_organization, certificate_logo_image_url=fake.word())
+
+        bad_program = ProgramDetails(
+            uuid=fake.uuid4(),
+            title=fake.word(),
+            type=fake.word(),
+            type_slug=fake.word(),
+            credential_title=fake.word(),
+            course_count=fake.random_digit(),
+            organizations=[bad_organization],
+            hours_of_effort=fake.random_digit(),
+            status=fake.word(),
+        )
+        good_program = dataclasses.replace(bad_program, organizations=[good_organization])
+        with mock.patch(
+            "credentials.apps.credentials.forms.get_program_details_by_uuid", return_value=bad_program
+        ) as mock_method:
             self.assertFalse(form.is_valid())
-            mock_method.assert_called_with(data["program_uuid"], ignore_cache=True)
+            mock_method.assert_called_with(data["program_uuid"], sc.site)
             self.assertEqual(
                 form.errors["program_uuid"][0],
                 "All authoring organizations of the program MUST have a certificate image defined!",
             )
 
         form = ProgramCertificateAdminForm(data)
-        with mock.patch.object(
-            SiteConfiguration, "get_program", return_value=self.GOOD_MOCK_API_PROGRAM
+        with mock.patch(
+            "credentials.apps.credentials.forms.get_program_details_by_uuid", return_value=good_program
         ) as mock_method:
             self.assertFalse(form.is_valid())
-            mock_method.assert_called_with(data["program_uuid"], ignore_cache=True)
+            mock_method.assert_called_with(data["program_uuid"], sc.site)
             self.assertNotIn("program_uuid", form.errors)

--- a/credentials/apps/credentials/tests/test_models.py
+++ b/credentials/apps/credentials/tests/test_models.py
@@ -13,7 +13,6 @@ from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
 
 from credentials.apps.catalog.data import OrganizationDetails, ProgramDetails
-from credentials.apps.core.models import SiteConfiguration
 from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials import constants
 from credentials.apps.credentials.exceptions import NoMatchingProgramException
@@ -167,15 +166,6 @@ class ProgramCertificateTests(SiteMixin, TestCase):
         with self.assertRaises(NoMatchingProgramException):
             # attempt to access the program_details property
             program_certificate.program_details  # pylint: disable=pointless-statement
-
-    def test_get_program_api_data(self):
-        """ Verify the method returns data from the Catalog API. """
-        program_certificate = ProgramCertificateFactory(site=self.site)
-        expected = {"uuid": program_certificate.program_uuid.hex}
-
-        with mock.patch.object(SiteConfiguration, "get_program", return_value=expected) as mock_method:
-            self.assertEqual(program_certificate.get_program_api_data(), expected)
-            mock_method.assert_called_with(program_certificate.program_uuid)
 
 
 class UserCredentialTests(TestCase):


### PR DESCRIPTION
Only changes credentials internals to use catalog data instead of
contacting discovery directly. Remove the get_program method and changes
all downstream consumers to use the catalog program instead.