### PR TITLE
Unpin edx-auth-backends

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -37,11 +37,11 @@ bleach==3.3.0
     #   -r requirements/production.txt
 bok-choy==1.1.1
     # via -r requirements/dev.txt
-boto3==1.17.55
+boto3==1.17.56
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.20.55
+botocore==1.20.56
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -283,7 +283,7 @@ git+https://github.com/edx/credentials-themes.git@0.1.61#egg=edx_credentials_the
     #   -r requirements/production.txt
 factory-boy==3.2.0
     # via -r requirements/dev.txt
-faker==8.1.0
+faker==8.1.1
     # via
     #   -r requirements/dev.txt
     #   factory-boy
@@ -600,7 +600,7 @@ rest-condition==1.0.3
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-drf-extensions
-s3transfer==0.4.1
+s3transfer==0.4.2
     # via
     #   -r requirements/production.txt
     #   boto3

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -213,9 +213,7 @@ djangorestframework==3.12.4
     #   edx-drf-extensions
     #   rest-condition
 docker-compose==1.29.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev.txt
+    # via -r requirements/dev.txt
 docker[ssh]==5.0.0
     # via
     #   -r requirements/dev.txt

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -238,9 +238,8 @@ edx-ace==0.1.17
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-edx-auth-backends==3.3.0
+edx-auth-backends==3.3.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
 edx-django-release-util==1.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -99,10 +99,8 @@ edx-ace==0.1.17
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-auth-backends==3.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+edx-auth-backends==3.3.3
+    # via -r requirements/base.in
 edx-django-release-util==1.0.0
     # via -r requirements/base.in
 edx-django-sites-extensions==3.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,10 +22,6 @@ virtualenv<20.2.2
 # https://openedx.atlassian.net/browse/MICROBA-929
 social-auth-core<4.0.3
 
-# New versions of this package are breaking authentication in this service.
-# this is a temporary constraint until we can isolate and resolve the issue.
-edx-auth-backends<=3.3.0
-
 # Newer versions require passing in lms_user_id rather than a username.
 # Ticket for adding LMS user IDs to Credentials: https://openedx.atlassian.net/browse/MICROBA-649
 edx-ace<1.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,9 +11,6 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-# Functional pin for dev.in
-docker-compose >= 1.5.1
-
 # This upgrade causes a failure in tests currently. We need to constrain it until we
 # can determine the cause of the failure. https://openedx.atlassian.net/browse/MICROBA-794
 virtualenv<20.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -158,9 +158,7 @@ djangorestframework==3.12.4
     #   edx-drf-extensions
     #   rest-condition
 docker-compose==1.29.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev.in
+    # via -r requirements/dev.in
 docker[ssh]==5.0.0
     # via docker-compose
 dockerpty==0.4.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -207,7 +207,7 @@ git+https://github.com/edx/credentials-themes.git@0.1.61#egg=edx_credentials_the
     # via -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==8.1.0
+faker==8.1.1
     # via
     #   -r requirements/test.txt
     #   factory-boy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -175,10 +175,8 @@ edx-ace==0.1.17
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-edx-auth-backends==3.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+edx-auth-backends==3.3.3
+    # via -r requirements/test.txt
 edx-django-release-util==1.0.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==3.0.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -12,9 +12,9 @@ attrs==20.3.0
     #   edx-ace
 bleach==3.3.0
     # via -r requirements/base.txt
-boto3==1.17.55
+boto3==1.17.56
     # via django-ses
-botocore==1.20.55
+botocore==1.20.56
     # via
     #   boto3
     #   s3transfer
@@ -316,7 +316,7 @@ rest-condition==1.0.3
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-s3transfer==0.4.1
+s3transfer==0.4.2
     # via boto3
 sailthru-client==2.2.3
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -126,10 +126,8 @@ edx-ace==0.1.17
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-edx-auth-backends==3.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+edx-auth-backends==3.3.3
+    # via -r requirements/base.txt
 edx-django-release-util==1.0.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==3.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -149,10 +149,8 @@ edx-ace==0.1.17
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-edx-auth-backends==3.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+edx-auth-backends==3.3.3
+    # via -r requirements/base.txt
 edx-django-release-util==1.0.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==3.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -180,7 +180,7 @@ git+https://github.com/edx/credentials-themes.git@0.1.61#egg=edx_credentials_the
     # via -r requirements/base.txt
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==8.1.0
+faker==8.1.1
     # via factory-boy
 filelock==3.0.12
     # via


### PR DESCRIPTION
Unpin edx-auth-backends and run _make upgrade_.

I think the auth issue we were seeing was fixed a while back: https://github.com/edx/auth-backends/pull/97

This also removes the _docker-compose_ pin, as it doesn't seem to be needed (and other repos don't have anything similar).