### PR TITLE
[feat] MB-1167 Certificate Availability API

### DIFF
--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -9,8 +9,8 @@ from django.urls import reverse
 from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
 from rest_framework.test import APIRequestFactory
-from credentials.apps.api.v2 import serializers
 
+from credentials.apps.api.v2 import serializers
 from credentials.apps.api.v2.serializers import (
     CourseCertificateSerializer,
     CredentialField,

--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -3,14 +3,12 @@ from logging import WARNING
 from uuid import uuid4
 
 import ddt
-from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
 from rest_framework.test import APIRequestFactory
 
-from credentials.apps.api.v2 import serializers
 from credentials.apps.api.v2.serializers import (
     CourseCertificateSerializer,
     CredentialField,

--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -9,6 +9,7 @@ from rest_framework.settings import api_settings
 from rest_framework.test import APIRequestFactory
 
 from credentials.apps.api.v2.serializers import (
+    CourseCertificateSerializer,
     CredentialField,
     UserCredentialAttributeSerializer,
     UserCredentialCreationSerializer,
@@ -281,4 +282,34 @@ class UserCredentialSerializerTests(TestCase):
         }
 
         actual = UserCredentialSerializer(user_credential, context={"request": request}).data
+        self.assertEqual(actual, expected)
+
+
+class CourseCertificateSerializerTests(TestCase):
+    def test_create_course_certificate(self):
+        course_run = CourseRunFactory()
+        course_certificate = CourseCertificateFactory(course_run=course_run)
+        actual = CourseCertificateSerializer(course_certificate).data
+        expected = {
+            "id": course_certificate.id,
+            "course_id": course_certificate.course_id,
+            "course_run": course_certificate.course_run.key,
+            "certificate_type": course_certificate.certificate_type,
+            "certificate_available_date": course_certificate.certificate_available_date,
+            "is_active": course_certificate.is_active,
+        }
+        self.assertEqual(actual, expected)
+
+    def test_missing_course_run(self):
+        # We should be able to create an entry without a course run
+        course_certificate = CourseCertificateFactory(course_run=None)
+        actual = CourseCertificateSerializer(course_certificate).data
+        expected = {
+            "id": course_certificate.id,
+            "course_id": course_certificate.course_id,
+            "course_run": None,
+            "certificate_type": course_certificate.certificate_type,
+            "certificate_available_date": course_certificate.certificate_available_date,
+            "is_active": course_certificate.is_active,
+        }
         self.assertEqual(actual, expected)

--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -316,10 +316,11 @@ class CourseCertificateSerializerTests(SiteMixin, TestCase):
         self.assertEqual(actual, expected)
 
     def test_create_without_course_run_raises_warning(self):
-        # even though you can create an entry without a course run, we want to make sure we are logging a warning when it is missing
+        # even though you can create an entry without a course run,
+        # we want to make sure we are logging a warning when it is missing
         with self.assertLogs(level=WARNING):
             Request = namedtuple("Request", ["site"])
-            serializer = CourseCertificateSerializer(context={"request": Request(site=self.site)}).create(
+            CourseCertificateSerializer(context={"request": Request(site=self.site)}).create(
                 validated_data={
                     "course_id": "DemoCourse0",
                     "certificate_type": "verified",
@@ -327,4 +328,3 @@ class CourseCertificateSerializerTests(SiteMixin, TestCase):
                     "certificate_available_date": None,
                 }
             )
-            print(dir(serializer))

--- a/credentials/apps/api/v2/urls.py
+++ b/credentials/apps/api/v2/urls.py
@@ -11,4 +11,5 @@ router = DefaultRouter()
 # as mentioned https://github.com/samgiles/slumber/issues/44
 router.register(r"credentials", views.CredentialViewSet, basename="credentials")
 router.register(r"grades", views.GradeViewSet, basename="grades")
+router.register(r"course_certificates", views.CourseCertificateViewSet, basename="course_certificates")
 urlpatterns += router.urls

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -13,11 +13,12 @@ from rest_framework.views import APIView, exception_handler
 from credentials.apps.api.v2.filters import UserCredentialFilter
 from credentials.apps.api.v2.permissions import CanReplaceUsername, UserCredentialPermissions
 from credentials.apps.api.v2.serializers import (
+    CourseCertificateSerializer,
     UserCredentialCreationSerializer,
     UserCredentialSerializer,
     UserGradeSerializer,
 )
-from credentials.apps.credentials.models import UserCredential
+from credentials.apps.credentials.models import CourseCertificate, UserCredential
 from credentials.apps.records.models import UserGrade
 
 
@@ -279,3 +280,11 @@ class UsernameReplacementView(APIView):
                 new_username,
             )
         return True
+
+
+class CourseCertificateViewSet(
+    mixins.UpdateModelMixin, mixins.RetrieveModelMixin, mixins.CreateModelMixin, viewsets.GenericViewSet
+):
+    queryset = CourseCertificate.objects.all()
+    serializer_class = CourseCertificateSerializer
+    lookup_field = "course_id"


### PR DESCRIPTION
This PR will create an API to expose the course certificate configuration so that the LMS can talk directly with Credentials and explicitly add the certificate availability date to a certificate configuration.

Previously, we were running into an issue where the LMS would send over a "visible date" that would be one of a few values; possibly the availability date, possibly the created date, modified date, etc. In order to reduce confusion and prevent bugs, we plan to add the availability date explicitly on any configuration that has one.