### PR TITLE
fix: fix credentials devstack provisioning after django debug toolbar change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ production-requirements: piptools ## Install requirements for production
 	npm install --no-save
 	pip-sync requirements/production.txt
 
+dev-requirements: piptools
+	npm install --also=dev
+	pip-sync requirements/all.txt
+
 all-requirements: piptools ## Install local and prod requirements
 	npm install
 	npm install --production --no-save


### PR DESCRIPTION
[MICROBA-1189]
- add new Makefile target for `dev-requirements` that ensures the django debug toolbar gets installed in the docker container

What I think is happening is that (currently) when Credentials is provisioned, when installing python requirements, we run `make requirements` and `make production-requirements` back to back. A side effect here is that `pip-sync` uninstalls the django debug toolbar since it is not a requirement in the `production.txt` requirements file(?).

This will be paired with an update to the `devstack` repo `provision-credentials.sh` script that will call this new Make target to ensure all the required packages are being installed during provisioning.