### PR TITLE
feat: add toggle for certificate_available_date

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -3,6 +3,7 @@ from datetime import timezone
 from os.path import abspath, dirname, join
 
 from django.conf.global_settings import LANGUAGES_BIDI
+from edx_toggles.toggles import WaffleSwitch
 
 from credentials.settings.utils import get_logger_config
 
@@ -485,6 +486,17 @@ ALLOWED_EMAIL_HTML_TAGS = [
     "strong",
     "ul",
 ]
+
+# .. toggle_name: USE_CERTIFICATE_AVAILABLE_DATE
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Toggle to control use of the certificate_available_date
+#   field during development.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2021-04-30
+# .. toggle_target_removal_date: 2021-06-01
+# .. toggle_tickets: https://openedx.atlassian.net/browse/MICROBA-1169, https://openedx.atlassian.net/browse/MICROBA-1198 (ticket for removal)
+USE_CERTIFICATE_AVAILABLE_DATE = WaffleSwitch("credentials.use_certificate_available_date", module_name=__name__)
 
 LOGO_TRADEMARK_URL = "https://edx-cdn.org/v3/default/logo-trademark.svg"
 LOGO_TRADEMARK_URL_PNG = "https://edx-cdn.org/v3/default/logo-trademark.png"

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -37,11 +37,11 @@ bleach==3.3.0
     #   -r requirements/production.txt
 bok-choy==1.1.1
     # via -r requirements/dev.txt
-boto3==1.17.60
+boto3==1.17.61
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.20.60
+botocore==1.20.61
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -70,6 +70,7 @@ click-log==0.3.2
 click==7.1.2
     # via
     #   -r requirements/dev.txt
+    #   -r requirements/production.txt
     #   black
     #   click-log
     #   code-annotations
@@ -77,7 +78,9 @@ click==7.1.2
 code-annotations==1.1.1
     # via
     #   -r requirements/dev.txt
+    #   -r requirements/production.txt
     #   edx-lint
+    #   edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/dev.txt
@@ -124,6 +127,7 @@ django-crum==0.7.9
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-django-utils
+    #   edx-toggles
 django-debug-toolbar==3.2.1
     # via -r requirements/dev.txt
 django-extensions==3.1.3
@@ -170,6 +174,7 @@ django-waffle==2.1.0
     #   -r requirements/production.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django-webpack-loader==0.7.0
     # via
     #   -r requirements/dev.txt
@@ -200,6 +205,7 @@ django==2.2.20
     #   edx-drf-extensions
     #   edx-i18n-tools
     #   edx-lint
+    #   edx-toggles
     #   rest-condition
     #   xss-utils
 djangorestframework==3.12.4
@@ -252,6 +258,7 @@ edx-django-utils==3.16.0
     #   -r requirements/production.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via
     #   -r requirements/dev.txt
@@ -272,13 +279,17 @@ edx-rest-api-client==5.3.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
+edx-toggles==4.1.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
 git+https://github.com/edx/credentials-themes.git@0.1.62#egg=edx_credentials_themes==0.1.62
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
 factory-boy==3.2.0
     # via -r requirements/dev.txt
-faker==8.1.1
+faker==8.1.2
     # via
     #   -r requirements/dev.txt
     #   factory-boy
@@ -527,7 +538,7 @@ python-dateutil==2.8.1
     #   edx-ace
     #   edx-drf-extensions
     #   faker
-python-dotenv==0.17.0
+python-dotenv==0.17.1
     # via
     #   -r requirements/dev.txt
     #   docker-compose

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -33,6 +33,7 @@ edx-django-utils
 edx-drf-extensions
 edx-opaque-keys
 edx-rest-api-client
+edx-toggles
 markdown
 mysqlclient
 newrelic

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,10 @@ cffi==1.14.5
     # via cryptography
 chardet==4.0.0
     # via requests
+click==7.1.2
+    # via code-annotations
+code-annotations==1.1.1
+    # via edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/base.in
@@ -34,7 +38,9 @@ defusedxml==0.7.1
 django-appconf==1.0.4
     # via django-statici18n
 django-crum==0.7.9
-    # via edx-django-utils
+    # via
+    #   edx-django-utils
+    #   edx-toggles
 django-extensions==3.1.3
     # via -r requirements/base.in
 django-filter==2.4.0
@@ -58,12 +64,14 @@ django-waffle==2.1.0
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django-webpack-loader==0.7.0
     # via -r requirements/base.in
 django==2.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
+    #   code-annotations
     #   django-appconf
     #   django-crum
     #   django-extensions
@@ -81,6 +89,7 @@ django==2.2.20
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-i18n-tools
+    #   edx-toggles
     #   rest-condition
     #   xss-utils
 djangorestframework==3.12.4
@@ -107,6 +116,7 @@ edx-django-utils==3.16.0
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via -r requirements/base.in
 edx-i18n-tools==0.5.3
@@ -116,6 +126,8 @@ edx-opaque-keys==2.2.0
     #   -r requirements/base.in
     #   edx-drf-extensions
 edx-rest-api-client==5.3.0
+    # via -r requirements/base.in
+edx-toggles==4.1.0
     # via -r requirements/base.in
 git+https://github.com/edx/credentials-themes.git@0.1.62#egg=edx_credentials_themes==0.1.62
     # via -r requirements/base.in
@@ -130,7 +142,9 @@ idna==2.10
 itypes==1.2.0
     # via coreapi
 jinja2==2.11.3
-    # via coreschema
+    # via
+    #   code-annotations
+    #   coreschema
 markdown==3.3.4
     # via -r requirements/base.in
 markupsafe==1.1.1
@@ -187,7 +201,9 @@ python-dateutil==2.8.1
 python-memcached==1.59
     # via -r requirements/base.in
 python-slugify==4.0.1
-    # via transifex-client
+    # via
+    #   code-annotations
+    #   transifex-client
 python3-openid==3.2.0
     # via social-auth-core
 pytz==2021.1
@@ -196,6 +212,7 @@ pytz==2021.1
     #   django
 pyyaml==5.4.1
     # via
+    #   code-annotations
     #   edx-django-release-util
     #   edx-i18n-tools
 requests-oauthlib==1.3.0
@@ -255,6 +272,7 @@ sqlparse==0.4.1
     # via django
 stevedore==3.3.0
     # via
+    #   code-annotations
     #   edx-ace
     #   edx-django-utils
     #   edx-opaque-keys

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -59,6 +59,7 @@ code-annotations==1.1.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
+    #   edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/test.txt
@@ -97,6 +98,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
+    #   edx-toggles
 django-debug-toolbar==3.2.1
     # via -r requirements/dev.in
 django-extensions==3.1.3
@@ -122,6 +124,7 @@ django-waffle==2.1.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django-webpack-loader==0.7.0
     # via -r requirements/test.txt
 django==2.2.20
@@ -148,6 +151,7 @@ django==2.2.20
     #   edx-drf-extensions
     #   edx-i18n-tools
     #   edx-lint
+    #   edx-toggles
     #   rest-condition
     #   xss-utils
 djangorestframework==3.12.4
@@ -184,6 +188,7 @@ edx-django-utils==3.16.0
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via -r requirements/test.txt
 edx-i18n-tools==0.5.3
@@ -199,11 +204,13 @@ edx-opaque-keys==2.2.0
     #   edx-drf-extensions
 edx-rest-api-client==5.3.0
     # via -r requirements/test.txt
+edx-toggles==4.1.0
+    # via -r requirements/test.txt
 git+https://github.com/edx/credentials-themes.git@0.1.62#egg=edx_credentials_themes==0.1.62
     # via -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==8.1.1
+faker==8.1.2
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -396,7 +403,7 @@ python-dateutil==2.8.1
     #   edx-ace
     #   edx-drf-extensions
     #   faker
-python-dotenv==0.17.0
+python-dotenv==0.17.1
     # via docker-compose
 python-memcached==1.59
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -12,9 +12,9 @@ attrs==20.3.0
     #   edx-ace
 bleach==3.3.0
     # via -r requirements/base.txt
-boto3==1.17.60
+boto3==1.17.61
     # via django-ses
-botocore==1.20.60
+botocore==1.20.61
     # via
     #   boto3
     #   s3transfer
@@ -30,6 +30,14 @@ chardet==4.0.0
     # via
     #   -r requirements/base.txt
     #   requests
+click==7.1.2
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+code-annotations==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -57,6 +65,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+    #   edx-toggles
 django-extensions==3.1.3
     # via -r requirements/base.txt
 django-filter==2.4.0
@@ -82,12 +91,14 @@ django-waffle==2.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django-webpack-loader==0.7.0
     # via -r requirements/base.txt
 django==2.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
+    #   code-annotations
     #   django-appconf
     #   django-crum
     #   django-extensions
@@ -106,6 +117,7 @@ django==2.2.20
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-i18n-tools
+    #   edx-toggles
     #   rest-condition
     #   xss-utils
 djangorestframework==3.12.4
@@ -134,6 +146,7 @@ edx-django-utils==3.16.0
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via -r requirements/base.txt
 edx-i18n-tools==0.5.3
@@ -145,6 +158,8 @@ edx-opaque-keys==2.2.0
     #   -r requirements/base.txt
     #   edx-drf-extensions
 edx-rest-api-client==5.3.0
+    # via -r requirements/base.txt
+edx-toggles==4.1.0
     # via -r requirements/base.txt
 git+https://github.com/edx/credentials-themes.git@0.1.62#egg=edx_credentials_themes==0.1.62
     # via -r requirements/base.txt
@@ -178,6 +193,7 @@ itypes==1.2.0
 jinja2==2.11.3
     # via
     #   -r requirements/base.txt
+    #   code-annotations
     #   coreschema
 jmespath==0.10.0
     # via
@@ -274,6 +290,7 @@ python-memcached==1.59
 python-slugify==4.0.1
     # via
     #   -r requirements/base.txt
+    #   code-annotations
     #   transifex-client
 python3-openid==3.2.0
     # via
@@ -288,6 +305,7 @@ pyyaml==5.4.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
+    #   code-annotations
     #   edx-django-release-util
     #   edx-i18n-tools
 requests-oauthlib==1.3.0
@@ -367,6 +385,7 @@ sqlparse==0.4.1
 stevedore==3.3.0
     # via
     #   -r requirements/base.txt
+    #   code-annotations
     #   edx-ace
     #   edx-django-utils
     #   edx-opaque-keys

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -41,14 +41,17 @@ click-log==0.3.2
     # via edx-lint
 click==7.1.2
     # via
+    #   -r requirements/base.txt
     #   black
     #   click-log
     #   code-annotations
     #   edx-lint
 code-annotations==1.1.1
     # via
+    #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-lint
+    #   edx-toggles
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -82,6 +85,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+    #   edx-toggles
 django-extensions==3.1.3
     # via -r requirements/base.txt
 django-filter==2.4.0
@@ -105,6 +109,7 @@ django-waffle==2.1.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django-webpack-loader==0.7.0
     # via -r requirements/base.txt
     # via
@@ -129,6 +134,7 @@ django-webpack-loader==0.7.0
     #   edx-drf-extensions
     #   edx-i18n-tools
     #   edx-lint
+    #   edx-toggles
     #   rest-condition
     #   xss-utils
 djangorestframework==3.12.4
@@ -157,6 +163,7 @@ edx-django-utils==3.16.0
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   edx-toggles
 edx-drf-extensions==6.5.0
     # via -r requirements/base.txt
 edx-i18n-tools==0.5.3
@@ -171,11 +178,13 @@ edx-opaque-keys==2.2.0
     #   edx-drf-extensions
 edx-rest-api-client==5.3.0
     # via -r requirements/base.txt
+edx-toggles==4.1.0
+    # via -r requirements/base.txt
 git+https://github.com/edx/credentials-themes.git@0.1.62#egg=edx_credentials_themes==0.1.62
     # via -r requirements/base.txt
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==8.1.1
+faker==8.1.2
     # via factory-boy
 filelock==3.0.12
     # via


### PR DESCRIPTION
This work adds a temporary WaffleSwitch to gate the use of the
certificate_available_date field on the CourseCertificate model while
we develop features around it.

This ONLY adds the switch, but doesn’t use it yet.

To use the toggle:

  1. In the waffle section of the django admin
     (< credentials host >admin/waffle/), add a new Switch with the name:
     `credentials.use_certificate_available_date`. Make sure it is
     "active".

  2. In the code, call the switch like this:
     ```
     from credentials.settings.base import USE_CERTIFICATE_AVAILABLE_DATE
     if USE_CERTIFICATE_AVAILABLE_DATE.is_enabled():
        # do your stuff here
     ```

Original ticket: https://openedx.atlassian.net/browse/MICROBA-1169
Ticket to remove flag: https://openedx.atlassian.net/browse/MICROBA-1198