### PR TITLE
MB-1167: CourseCertificateSerializer Fix

### DIFF
--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -266,13 +266,14 @@ class CourseCertificateSerializer(serializers.ModelSerializer):
         model = CourseCertificate
         fields = (
             "id",
+            "site",
             "course_id",
             "course_run",
             "certificate_type",
             "certificate_available_date",
             "is_active",
         )
-        read_only_fields = ("id", "course_run")
+        read_only_fields = ("id", "course_run", "site")
 
     def create(self, validated_data):
         site = self.context["request"].site
@@ -287,16 +288,15 @@ class CourseCertificateSerializer(serializers.ModelSerializer):
                 "Course run certificate failed to create "
                 f"because the course run [{course_id}] doesn't exist in the catalog"
             )
-
-        cert, _ = CourseCertificate.objects.get_or_create(
+        #Check if the cert already exists, attempt to update the course_run and cert date
+        cert, _ = CourseCertificate.objects.update_or_create(
             course_id=course_id,
             site=site,
-            course_run=course_run,
             certificate_type=validated_data["certificate_type"],
-            certificate_available_date=validated_data["certificate_available_date"],
-            is_active=validated_data["is_active"],
             defaults={
-                "is_active": True,
+                "is_active": validated_data["is_active"],
+                "course_run": course_run,
+                "certificate_available_date": validated_data["certificate_available_date"],
             },
         )
         return cert

--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -288,7 +288,7 @@ class CourseCertificateSerializer(serializers.ModelSerializer):
                 "Course run certificate failed to create "
                 f"because the course run [{course_id}] doesn't exist in the catalog"
             )
-        #Check if the cert already exists, attempt to update the course_run and cert date
+        # Check if the cert already exists, attempt to update the course_run and cert date
         cert, _ = CourseCertificate.objects.update_or_create(
             course_id=course_id,
             site=site,

--- a/credentials/apps/api/v2/tests/test_serializers.py
+++ b/credentials/apps/api/v2/tests/test_serializers.py
@@ -289,10 +289,12 @@ class UserCredentialSerializerTests(TestCase):
 class CourseCertificateSerializerTests(SiteMixin, TestCase):
     def test_create_course_certificate(self):
         course_run = CourseRunFactory()
-        course_certificate = CourseCertificateFactory(course_run=course_run)
-        actual = CourseCertificateSerializer(course_certificate).data
+        course_certificate = CourseCertificateFactory(site=self.site, course_run=course_run)
+        Request = namedtuple("Request", ["site"])
+        actual = CourseCertificateSerializer(course_certificate, context={"request": Request(site=self.site)}).data
         expected = {
             "id": course_certificate.id,
+            "site": self.site.id,
             "course_id": course_certificate.course_id,
             "course_run": course_certificate.course_run.key,
             "certificate_type": course_certificate.certificate_type,
@@ -303,12 +305,14 @@ class CourseCertificateSerializerTests(SiteMixin, TestCase):
 
     def test_missing_course_run(self):
         # We should be able to create an entry without a course run
-        course_certificate = CourseCertificateFactory(course_run=None)
-        actual = CourseCertificateSerializer(course_certificate).data
+        course_certificate = CourseCertificateFactory(site=self.site, course_run=None)
+        Request = namedtuple("Request", ["site"])
+        actual = CourseCertificateSerializer(course_certificate, context={"request": Request(site=self.site)}).data
         expected = {
             "id": course_certificate.id,
-            "course_id": course_certificate.course_id,
+            "site": self.site.id,
             "course_run": None,
+            "course_id": course_certificate.course_id,
             "certificate_type": course_certificate.certificate_type,
             "certificate_available_date": course_certificate.certificate_available_date,
             "is_active": course_certificate.is_active,

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -4,6 +4,7 @@ from django.apps import apps
 from django.db import transaction
 from django.db.models import Q
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.permissions import JwtRestrictedApplication
 from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.exceptions import Throttled
 from rest_framework.response import Response
@@ -287,4 +288,5 @@ class CourseCertificateViewSet(
 ):
     queryset = CourseCertificate.objects.all()
     serializer_class = CourseCertificateSerializer
+    permission_classes = (permissions.IsAdminUser, )
     lookup_field = "course_id"

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -4,7 +4,6 @@ from django.apps import apps
 from django.db import transaction
 from django.db.models import Q
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from edx_rest_framework_extensions.permissions import JwtRestrictedApplication
 from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.exceptions import Throttled
 from rest_framework.response import Response

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -287,5 +287,5 @@ class CourseCertificateViewSet(
 ):
     queryset = CourseCertificate.objects.all()
     serializer_class = CourseCertificateSerializer
-    permission_classes = (permissions.IsAdminUser, )
+    permission_classes = (permissions.IsAdminUser,)
     lookup_field = "course_id"


### PR DESCRIPTION
[fix] Add permisssions and fix CourseCertificateSerializer

The CourseCertificateSerializer needed permission for the LMS
credentials_service_worker to operate properly. I opted for the admin
user permission instead of writing its own, because the worker should be
the only one making changes with this API anyway.

I've also reworked the serializers create() function to fix it. The
update portion of update_or_create() was not properly working because of
the unique together constraint on the model. Some of the tests were
modified to reflect the change made to create().