### PR TITLE
feat: use certificate_available_date field for filters

### DIFF
--- a/credentials/apps/credentials/tests/factories.py
+++ b/credentials/apps/credentials/tests/factories.py
@@ -20,6 +20,7 @@ class CourseCertificateFactory(AbstractCertificateFactory):
     course_id = factory.Sequence(lambda o: "course-%d" % o)
     certificate_type = constants.CertificateType.HONOR
     is_active = True
+    certificate_available_date = None
 
 
 class ProgramCertificateFactory(AbstractCertificateFactory):


### PR DESCRIPTION
This commit updates / adds some utility methods to use our new
certificate_available_date field on CourseCertificate (instead of the
visible_date on UserCredentialAttribute) for any methods that need
to filter certs to show only those that should be visible (i.e., whose
certificate_availbable_date is not in the future).

The filter_visible method (altered here) is used in the following
places:

  - get_record_data: a method called by ProgramRecordView and
    ProgramRecordCsvView. It provides all the record data for a given
    user and program--but only the visible course and program
    certificates

  - RecordsListBaseView: gets all the credentials for a given user,
    sorted by program or course certificate type—-but only wants
    the visible ones.

  - handle_only_visible: through the UserCredentialFilter. This allows
    callers of the credentials api to filter by this visibility.
		(This is used by edx-platform.)

This work is gated behind the USE_CERTIFICATE_AVAILABLE_DATE toggle
while development is in progress.

In partial fulfillment of MICROBA-1170 and MICROBA-1171.