### PR TITLE
[feat] Credentials masters CourseCertificate support

### DIFF
--- a/credentials/apps/credentials/constants.py
+++ b/credentials/apps/credentials/constants.py
@@ -21,3 +21,4 @@ class CertificateType:
     VERIFIED = "verified"
     PROFESSIONAL = "professional"
     NO_ID_PROFESSIONAL = "no-id-professional"
+    MASTERS = "masters"

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -215,6 +215,7 @@ class CourseCertificate(AbstractCertificate):
             constants.CertificateType.PROFESSIONAL,
             constants.CertificateType.VERIFIED,
             constants.CertificateType.NO_ID_PROFESSIONAL,
+            constants.CertificateType.MASTERS
         ),
     )
     user_credentials = GenericRelation(

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -215,7 +215,7 @@ class CourseCertificate(AbstractCertificate):
             constants.CertificateType.PROFESSIONAL,
             constants.CertificateType.VERIFIED,
             constants.CertificateType.NO_ID_PROFESSIONAL,
-            constants.CertificateType.MASTERS
+            constants.CertificateType.MASTERS,
         ),
     )
     user_credentials = GenericRelation(


### PR DESCRIPTION
While trying to update the available_date for CourseCertificates in
credentials, we were getting errors that master's program course
certificates were not being properly updated. this add's Masters to the
list of valid CourseCertificate configurations.