### PR TITLE
chore: Add temporary pin for edx-drf-extensions to unblock make upgrade

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,3 +25,7 @@ django-webpack-loader<1.0.0
 
 # The update to 3.0.0 contains some large breaking changes. (MICROBA-1427)
 django-hijack<3.0.0
+
+# edx-drf-extension's upgrade to 7.0.0 is in conflict with the common-constraints' pinning of pyjwt[crypto]
+# See MICROBA-1435
+edx-drf-extensions<7.0.0


### PR DESCRIPTION
Add temporary pin for _edx-drf-extensions_ to unblock make upgrade

edx-drf-extensions' recent change to use **pyjwt[crypto]==2.1.0** seems to be in conflict with the common constraint pin of **pyjwt[crypto]==1.7.1** and results in this error when trying to upgrade credentials:

> # The following packages are considered to be unsafe in a requirements file:
> # pip
> # setuptools
> pip-compile --rebuild --upgrade -o requirements/base.txt requirements/base.in
> Could not find a version that matches pyjwt[crypto]==1.7.1,>=2.1.0 (from -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt (line 22))
> Tried: 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6, 0.1.7, 0.1.8, 0.1.9, 0.2.0, 0.2.1, 0.2.3, 0.2.3, 0.3.0, 0.3.0, 0.3.1, 0.3.1, 0.3.2, 0.3.2, 0.4.0, 0.4.0, 0.4.1, 0.4.1, 0.4.2, 0.4.2, 0.4.3, 0.4.3, 1.0.0, 1.0.0, 1.0.1, 1.0.1, 1.1.0, 1.1.0, 1.3.0, 1.3.0, 1.4.0, 1.4.0, 1.4.1, 1.4.1, 1.4.2, 1.4.2, 1.5.0, 1.5.0, 1.5.1, 1.5.1, 1.5.2, 1.5.2, 1.5.3, 1.5.3, 1.6.0, 1.6.0, 1.6.1, 1.6.1, 1.6.3, 1.6.3, 1.6.4, 1.6.4, 1.7.0, 1.7.0, 1.7.1, 1.7.1, 2.0.0, 2.0.0, 2.0.1, 2.0.1, 2.1.0, 2.1.0
> Skipped pre-versions: 2.0.0a1, 2.0.0a1, 2.0.0a2, 2.0.0a2
> There are incompatible versions in the resolved dependencies:
>   pyjwt[crypto]==1.7.1 (from -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt (line 22))
>   PyJWT (from edx-auth-backends==3.4.0->-r requirements/base.in (line 30))
>   PyJWT (from edx-rest-api-client==5.4.0->-r requirements/base.in (line 36))
>   pyjwt[crypto]>=2.1.0 (from edx-drf-extensions==7.0.0->-r requirements/base.in (line 34))
> make: *** [Makefile:52: upgrade] Error 2
> root@credentials:/edx/app/credentials/credentials#

MICROBA-1435