### PR TITLE
Add success notificate to upgrade job

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -67,3 +67,17 @@ jobs:
           to: aperture@edx.opsgenie.net
           from: github-actions <github-actions@edx.org>
           body: Upgrade python requirements workflow in ${{github.repository}} failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          
+      # Used to auto-close alerts once they start passing again.
+      - name: Send success notification
+        if: ${{ !failure() }}
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: email-smtp.us-east-1.amazonaws.com
+          server_port: 465
+          username: ${{secrets.EDX_SMTP_USERNAME}}
+          password: ${{secrets.EDX_SMTP_PASSWORD}}
+          subject: Upgrade python requirements workflow succeeded in ${{github.repository}}
+          to: aperture@edx.opsgenie.net
+          from: github-actions <github-actions@edx.org>
+          body: Upgrade python requirements workflow in ${{github.repository}} succeeded! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Success notification allows us to autoclose alerts once they're fixed.