### PR TITLE
feat: Add dockerfile and push image to Dockerhub

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,0 +1,23 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v1
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: openedx/credentials
+          tags: latest,${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,97 @@
+FROM ubuntu:focal as app
+MAINTAINER devops@edx.org
+
+
+# Packages installed:
+# git; Used to pull in particular requirements from github rather than pypi,
+# and to check the sha of the code checkout.
+
+# language-pack-en locales; ubuntu locale support so that system utilities have a consistent
+# language and time zone.
+
+# python; ubuntu doesnt ship with python, so this is the python we will use to run the application
+
+# python3-pip; install pip to install application requirements.txt files
+
+# libssl-dev; # mysqlclient wont install without this.
+
+# libmysqlclient-dev; to install header files needed to use native C implementation for
+# MySQL-python for performance gains.
+
+# wget to download a watchman binary archive
+
+# unzip to unzip a watchman binary archive
+
+# If you add a package here please include a comment above describing what it is used for
+RUN apt-get update && \
+apt-get install -y software-properties-common && \
+apt-add-repository -y ppa:deadsnakes/ppa && apt-get update && \
+apt-get upgrade -qy && apt-get install language-pack-en locales git \
+python3.8-dev python3.8-venv libmysqlclient-dev libssl-dev build-essential wget unzip -qy && \
+rm -rf /var/lib/apt/lists/*
+
+# Create Python env
+ENV VIRTUAL_ENV=/edx/app/credentials/venvs/credentials
+RUN python3.8 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Create Node env
+RUN pip install nodeenv
+ENV NODE_ENV=/edx/app/credentials/nodeenvs/credentials
+RUN nodeenv $NODE_ENV --node=12.11.1 --prebuilt
+ENV PATH="$NODE_ENV/bin:$PATH"
+RUN npm install -g npm@6.12.1
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV DJANGO_SETTINGS_MODULE credentials.settings.production
+
+EXPOSE 18150
+RUN useradd -m --shell /bin/false app
+
+# Install watchman
+RUN wget https://github.com/facebook/watchman/releases/download/v2020.08.17.00/watchman-v2020.08.17.00-linux.zip
+RUN unzip watchman-v2020.08.17.00-linux.zip
+RUN mkdir -p /usr/local/{bin,lib} /usr/local/var/run/watchman
+RUN cp watchman-v2020.08.17.00-linux/bin/* /usr/local/bin
+RUN cp watchman-v2020.08.17.00-linux/lib/* /usr/local/lib
+RUN chmod 755 /usr/local/bin/watchman
+RUN chmod 2777 /usr/local/var/run/watchman
+
+# Now install credentials
+WORKDIR /edx/app/credentials/credentials
+
+# Copy the requirements explicitly even though we copy everything below
+# this prevents the image cache from busting unless the dependencies have changed.
+COPY requirements/production.txt /edx/app/credentials/credentials/requirements/production.txt
+COPY requirements/pip_tools.txt /edx/app/credentials/credentials/requirements/pip_tools.txt
+
+# Dependencies are installed as root so they cannot be modified by the application user.
+RUN pip install -r requirements/pip_tools.txt
+RUN pip install -r requirements/production.txt
+
+RUN mkdir -p /edx/var/log
+
+# Code is owned by root so it cannot be modified by the application user.
+# So we copy it before changing users.
+USER app
+
+# Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
+CMD gunicorn --workers=2 --name credentials -c /edx/app/credentials/credentials/credentials/docker_gunicorn_configuration.py --log-file - --max-requests=1000 credentials.wsgi:application
+
+# This line is after the requirements so that changes to the code will not
+# bust the image cache
+COPY . /edx/app/credentials/credentials
+
+FROM app as newrelic
+RUN pip install newrelic
+CMD newrelic-admin run-program gunicorn --workers=2 --name credentials -c /edx/app/credentials/credentials/credentials/docker_gunicorn_configuration.py --log-file - --max-requests=1000 credentials.wsgi:application
+
+
+FROM app as devstack
+USER root
+RUN pip install -r /edx/app/credentials/credentials/requirements/dev.txt
+USER app
+CMD gunicorn --reload --workers=2 --name credentials -c /edx/app/credentials/credentials/credentials/docker_gunicorn_configuration.py --log-file - --max-requests=1000 credentials.wsgi:application

--- a/credentials/docker_gunicorn_configuration.py
+++ b/credentials/docker_gunicorn_configuration.py
@@ -1,0 +1,60 @@
+"""
+gunicorn configuration file: http://docs.gunicorn.org/en/develop/configure.html
+"""
+import multiprocessing  # pylint: disable=unused-import
+
+from django.conf import settings
+from django.core import cache as django_cache
+from django.core.management import call_command
+
+
+preload_app = True
+timeout = 300
+bind = "0.0.0.0:18150"
+
+workers = 2
+
+
+def pre_request(worker, req):
+    worker.log.info(f"{req.method} {req.path}")
+
+
+def close_all_caches():
+    """
+    Close the cache so that newly forked workers cannot accidentally share
+    the socket with the processes they were forked from. This prevents a race
+    condition in which one worker could get a cache response intended for
+    another worker.
+    We do this in a way that is safe for 1.4 and 1.8 while we still have some
+    1.4 installations.
+    """
+    if hasattr(django_cache, "caches"):
+        get_cache = django_cache.caches.__getitem__
+    else:
+        get_cache = django_cache.get_cache  # pylint: disable=no-member
+    for cache_name in settings.CACHES:
+        cache = get_cache(cache_name)
+        if hasattr(cache, "close"):
+            cache.close()
+
+    # The 1.4 global default cache object needs to be closed also: 1.4
+    # doesn't ensure you get the same object when requesting the same
+    # cache. The global default is a separate Python object from the cache
+    # you get with get_cache("default"), so it will have its own connection
+    # that needs to be closed.
+    cache = django_cache.cache
+    if hasattr(cache, "close"):
+        cache.close()
+
+
+def post_fork(server, worker):  # pylint: disable=unused-argument
+    close_all_caches()
+
+
+def when_ready(server):  # pylint: disable=unused-argument
+    """
+    When in debug mode, run Django's `check` to better match what `manage.py runserver` does.
+    Helps find common errors.
+    """
+    if settings.DEBUG:
+        call_command("check")


### PR DESCRIPTION
This image builds on our existing (non-ansible) Dockerfiles with the
following exceptions:
- It's the first to require node to build static assets. I've followed
the pattern we use in the ansible builds where we use nodeenv and I've
also taken the node and npm versions from ansible. This pattern may
change in the future but for now I'm prioritizing consistency with the
existing images.
- This is also the first one being used in devstack, so to utilize
existing devstack code, the folder structure has to have an additional
layer. The repo folder will live at /edx/app/credentials/credentials
instead of the /edx/app/<service> that other's use.

I tested this by building the image locally and pointing my devstack at it. 