### PR TITLE
feat: Use date override on Program Record

### DIFF
--- a/credentials/apps/credentials/tests/factories.py
+++ b/credentials/apps/credentials/tests/factories.py
@@ -1,3 +1,4 @@
+import datetime
 import uuid
 
 import factory
@@ -49,6 +50,13 @@ class UserCredentialAttributeFactory(factory.django.DjangoModelFactory):
     user_credential = factory.SubFactory(UserCredentialFactory)
     name = factory.Sequence(lambda o: "name-%d" % o)
     value = factory.Sequence(lambda o: "value-%d" % o)
+
+
+class UserCredentialDateOverrideFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.UserCredentialDateOverride
+
+    date = datetime.date(2021, 5, 11)
 
 
 class SignatoryFactory(factory.django.DjangoModelFactory):

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -25,7 +25,7 @@ from credentials.apps.catalog.models import Pathway, Program
 from credentials.apps.core.models import User
 from credentials.apps.core.views import ThemeViewMixin
 from credentials.apps.credentials.models import ProgramCertificate, UserCredential
-from credentials.apps.credentials.utils import filter_visible, get_credential_visible_dates
+from credentials.apps.credentials.utils import filter_visible, get_credential_visible_date, get_credential_visible_dates
 from credentials.apps.records.constants import UserCreditPathwayStatus
 from credentials.apps.records.messages import ProgramCreditRequest
 from credentials.apps.records.models import ProgramCertRecord, UserCreditPathway, UserGrade
@@ -183,7 +183,8 @@ def get_record_data(user, program_uuid, site, platform_name=None):
 
         # If the user has taken the course, show the course_run info for the highest grade
         elif grade is not None and grade.course_run == course_run:
-            issue_date = visible_dates[user_credential_dict[course_run.key]]
+            user_credential = user_credential_dict.get(course_run.key)
+            issue_date = get_credential_visible_date(user_credential, use_date_override=True)
             course_data.append(
                 {
                     "name": course_run.title,


### PR DESCRIPTION
When displaying the Program Record, use the date override (if present)
for the date value in the "Date Earned" column. This will make the
Program Record match the date displayed on the learner’s course
certificate.

<img width="1426" alt="Screen Shot 2021-08-20 at 3 16 59 PM" src="https://user-images.githubusercontent.com/26205183/130294253-9d495506-737f-4ac4-aa06-5d7222ecfc16.png">

# NOTE
**This will only display properly if the `USE_CERTIFICATE_AVAILABLE_DATE` waffle switch is enabled.** No, these changes are not related to that feature, but take my choice to leave this out of the old code paths as a bet that we’ll move forward and clean up that old code.