### PR TITLE
fix: corrects issue with issue_date and visible_date

### DIFF
--- a/credentials/apps/credentials/tests/test_views.py
+++ b/credentials/apps/credentials/tests/test_views.py
@@ -288,6 +288,22 @@ class RenderCredentialViewTests(SiteMixin, TestCase):
         response = self._render_user_credential()
         self.assertContains(response, "Issued May 1994")
 
+    @override_switch("credentials.use_certificate_available_date", active=True)
+    @responses.activate
+    def test_visible_date_as_issue_date_with_no_cert_availability_date_date(self):
+        """Verify that the view renders the visible_date as the issue date."""
+        for course_user_credential in self.course_user_credentials:
+            factories.UserCredentialAttributeFactory(
+                user_credential=course_user_credential,
+                name="visible_date",
+                value="2021-01-01T01:01:01Z",
+            )
+        for cert in self.course_certificates:
+            cert.certificate_available_date = None
+            cert.save()
+        response = self._render_user_credential()
+        self.assertContains(response, "Issued January 2021")
+
     @responses.activate
     def test_signatory_organization_name_override(self):
         """Verify that the view response contain signatory organization name if signatory have organization."""

--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -663,7 +663,6 @@ class ProgramRecordViewTests(SiteMixin, TestCase):
         response = self.client.get(reverse("records:private_programs", kwargs={"uuid": self.program.uuid.hex}))
         self.assertEqual(json.loads(response.context_data["record"])["program"]["completed"], completed)
 
-    # The following three tests are the same as the previous three, but with the
     # USE_CERTIFICATE_AVAILABLE_DATE waffle switch enabled. Clean up previous
     # tests in MICROBA-1198.
     @override_switch("credentials.use_certificate_available_date", active=True)


### PR DESCRIPTION
This PR fixes an issue where the Program certificate would show an
incorrect issue date based on when a course cert was created in
Credentials rather than when it was issued from the LMS.