### PR TITLE
BOM-2782: Use Deployment Monitoring Middleware in settings

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -78,6 +78,7 @@ INSTALLED_APPS += PROJECT_APPS
 
 MIDDLEWARE = (
     "corsheaders.middleware.CorsMiddleware",
+    "edx_django_utils.monitoring.DeploymentMonitoringMiddleware",
     "edx_django_utils.cache.middleware.RequestCacheMiddleware",
     "edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
**Issue:** [BOM-2782](https://openedx.atlassian.net/browse/BOM-2782)

### Description
- Added the `DeploymentMonitroringMiddleware` to record `Django` and `Python` versions in the `NewRelic`.
