### PR TITLE
chore: pin pyyaml version to fix upgrade job

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,3 +15,7 @@ Django<4.0
 
 # The update to 3.0.0 contains some large breaking changes. (MICROBA-1427)
 django-hijack<3.0.0
+
+# The update to pyyaml 6.x failed as docker-compose wants <6,>=3.10. Pinning to <6.0. This constraint will be
+# re-evaluated as part of MICROBA-1556.
+pyyaml<6.0


### PR DESCRIPTION
Temporarily pins `pyyaml` to versions < 6.0. The upgrade job started failing after `pyyaml` 6.x was released because `docker-compose` is looking for versions <6.0, >=3.10.

This pin will be re-evaluated and removed as part of MICROBA-1556.