### PR TITLE
build: tweak dockerfile; build and push both base and dev images

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Images
 
 on:
   push:
@@ -15,29 +15,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1
-        with:
-          push: ${{ github.event_name != 'pull_request' }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: openedx/credentials
-          tags: latest,${{ github.sha }}
-
-      - name: Get open release name
-        id: get-open-release
-        if: startsWith(github.ref, 'refs/tags/open-release/')
+      # Use the release name as the image tag if we're building an open release tag.
+      # Examples: if we're building 'open-release/maple.1', tag the image as 'maple.1'.
+      # Otherwise, we must be building from a push to master, so use 'latest'.
+      - name: Get tag name
+        id: get-tag-name
         uses: actions/github-script@v5
         with:
-          script: return context.ref.split('refs/tags/open-release/')[1]
+          script: |
+            const tagName = startsWith(github.ref, 'refs/tags/open-release/')
+                          ? context.ref.split('refs/tags/open-release/')[1]
+                          : 'latest';
+            console.log('Will use tag: ' + tagName);
+            return tagName;
           result-encoding: string
 
-      - name: Build and push Docker images
+      - name: Build and push base Docker image
         uses: docker/build-push-action@v1
-        if: startsWith(github.ref, 'refs/tags/open-release/')
         with:
           push: ${{ github.event_name != 'pull_request' }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          target: base
           repository: openedx/credentials
-          tags: ${{steps.get-open-release.outputs.result}}
+          tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
+
+      - name: Build and push dev Docker image
+        uses: docker/build-push-action@v1
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          target: dev
+          repository: openedx/credentials-dev
+          tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}


### PR DESCRIPTION
## Description

build: tweak dockerfile; build and push both base and dev images

dockerfile changes:
* rename stages ('app', 'devstack') to ('base', 'dev')
  to match edx-platform's Dockerfile.
* add comment to top of dockerfile warnings of its experimental
  dev-only state.
* remove newrelic build stage, which doesn't belong in the
  core openedx repository.
* touch ../credentials_env for devstack compatibility.


## Testing instructions

See the testing instructions for the [devstack PR](https://github.com/edx/devstack/pull/866).

## Supporting information

This is a dependency attempt to [use the experimental images in devstack](https://github.com/edx/devstack/pull/866), which itself is part of the effort to [move off of edxops DockerHub org images](https://github.com/edx/devstack/issues/869).
