### PR TITLE
build: fix get-tag-name in docker push workflow

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -23,9 +23,8 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            const tagName = startsWith(github.ref, 'refs/tags/open-release/')
-                          ? context.ref.split('refs/tags/open-release/')[1]
-                          : 'latest';
+            const releasePrefix = 'refs/tags/open-release/';
+            const tagName = context.ref.split(releasePrefix)[1] || 'latest';
             console.log('Will use tag: ' + tagName);
             return tagName;
           result-encoding: string


### PR DESCRIPTION
@Tj-Tracy do you mind reviewing this too? My [last PR](https://github.com/edx/credentials/pull/1510) had a bug in the GitHub action.

I hope it works... I wish I knew a way to test these workflows locally!