### PR TITLE
feat: enabling easy theme translations (#2945)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ requirements: piptools ## Install requirements for local development
 	pip-sync requirements/dev.txt
 
 piptools:
+	pip install -U 'pip<25.3'
 	pip install -q -r requirements/pip_tools.txt
 
 define COMMON_CONSTRAINTS_TEMP_COMMENT

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,8 @@ fake_translations: extract_translations dummy_translations compile_translations 
 
 pull_translations:
 	find credentials/conf/locale -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
-	atlas pull $(ATLAS_OPTIONS) translations/credentials/credentials/conf/locale:credentials/conf/locale
+	atlas pull $(ATLAS_OPTIONS) translations/credentials/credentials/conf/locale:credentials/conf/locale \
+		$(ATLAS_EXTRA_SOURCES)
 	python manage.py compilemessages
 
 	@echo "Translations have been pulled via Atlas and compiled."


### PR DESCRIPTION
making it easy for local configuration to  pull inextra configured translations, such as credentials-themes  or any other plug-ins. Also updates pins pip [per prior art](https://github.com/openedx/enterprise-access/pull/919/) to deal with a github-only, fork-only CI failure.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
