### PR TITLE
style: adjust padding for accomplishment title in print rendering

### DIFF
--- a/credentials/apps/credentials_theme_openedx/static/sass/_print-rendering.scss
+++ b/credentials/apps/credentials_theme_openedx/static/sass/_print-rendering.scss
@@ -26,7 +26,7 @@
         @include text-align(left);
         top: 0 !important;
         box-shadow: none;
-        padding: 0.625rem 2.5rem !important;
+        padding: 5% 5% 3% !important;
         background-color: $white;
 
         .wrapper-accomplishment-title {


### PR DESCRIPTION

This pull request makes a small adjustment to the print rendering styles for credentials. The padding for a specific element has been changed from fixed `rem` units to percentage-based values, which should improve layout responsiveness when printing.

**JIRA:** https://2u-internal.atlassian.net/browse/LP-530