### PR TITLE
chore: bump edx-credentials-themes dependency to version 0.5.9

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -294,7 +294,7 @@ edx-ccx-keys==2.0.2
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   openedx-events
-edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.6
+edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.9
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -55,4 +55,4 @@ xss-utils
 
 # TODO Install in configuration
 git+https://github.com/openedx/event-bus-redis.git@v0.5.0
-git+https://github.com/openedx/credentials-themes.git@0.5.6#egg=edx_credentials_themes==0.5.6
+git+https://github.com/openedx/credentials-themes.git@0.5.9#egg=edx_credentials_themes==0.5.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -145,7 +145,7 @@ edx-auth-backends==4.6.2
     # via -r requirements/base.in
 edx-ccx-keys==2.0.2
     # via openedx-events
-edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.6
+edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.9
     # via -r requirements/base.in
 edx-django-release-util==1.5.0
     # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -223,7 +223,7 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/test.txt
     #   openedx-events
-edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.6
+edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.9
     # via -r requirements/test.txt
 edx-django-release-util==1.5.0
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -184,7 +184,7 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/base.txt
     #   openedx-events
-edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.6
+edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.9
     # via -r requirements/base.txt
 edx-django-release-util==1.5.0
     # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -201,7 +201,7 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/base.txt
     #   openedx-events
-edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.6
+edx-credentials-themes @ git+https://github.com/openedx/credentials-themes.git@0.5.9
     # via -r requirements/base.txt
 edx-django-release-util==1.5.0
     # via -r requirements/base.txt


### PR DESCRIPTION
This pull request updates the `edx-credentials-themes` dependency to version 0.5.9 across all requirement files. This ensures that all environments (base, development, production, and test) use the latest version of the theme package.

Dependency updates:

* Upgraded `edx-credentials-themes` from version 0.5.6 to 0.5.9

**JIRA:** https://2u-internal.atlassian.net/browse/LP-530